### PR TITLE
Podfile 추가, 환율 API 요청을 위한 네트워크 모델 구현

### DIFF
--- a/BoostPocket/.swiftlint.yml
+++ b/BoostPocket/.swiftlint.yml
@@ -1,0 +1,15 @@
+included:
+
+excluded:
+- Pods
+
+disabled_rules:
+- trailing_whitespace
+- identifier_name
+- todo
+- function_parameter_count
+- line_length
+- type_name
+
+force_cast: warning
+line_length: 250

--- a/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
+++ b/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
@@ -7,12 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3725D4AFE6D2AE5B6A21D483 /* Pods_BoostPocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05B97464333E742D61CD6648 /* Pods_BoostPocket.framework */; };
+		470EEBDB802C6552ECB4E189 /* Pods_BoostPocketTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81FEEDDEA3FA0D3B4F97EE2F /* Pods_BoostPocketTests.framework */; };
 		5C3DAF2F2566576000178EA0 /* CountryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3DAF2D2566576000178EA0 /* CountryListViewController.swift */; };
 		5C3DAF302566576000178EA0 /* CountryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5C3DAF2E2566576000178EA0 /* CountryListViewController.xib */; };
 		5C3DAF3525665F0200178EA0 /* CountryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3DAF3325665F0200178EA0 /* CountryCell.swift */; };
 		5C3DAF3625665F0200178EA0 /* CountryCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5C3DAF3425665F0200178EA0 /* CountryCell.xib */; };
 		5C3DAF3A25666A8000178EA0 /* TravelDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5C3DAF3925666A8000178EA0 /* TravelDetail.storyboard */; };
 		5C3DAF3E25666B4D00178EA0 /* TravelProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3DAF3D25666B4D00178EA0 /* TravelProfileViewController.swift */; };
+		9572F977256B5397003049CB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 9572F976256B5397003049CB /* .swiftlint.yml */; };
 		95A42E7A25664DBE0007810C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E7925664DBE0007810C /* AppDelegate.swift */; };
 		95A42E7C25664DBE0007810C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E7B25664DBE0007810C /* SceneDelegate.swift */; };
 		95A42E7E25664DBE0007810C /* TravelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E7D25664DBE0007810C /* TravelListViewController.swift */; };
@@ -34,12 +37,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		05B97464333E742D61CD6648 /* Pods_BoostPocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BoostPocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		460E2B0DBA1F49A0D275F156 /* Pods-BoostPocketTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BoostPocketTests.release.xcconfig"; path = "Target Support Files/Pods-BoostPocketTests/Pods-BoostPocketTests.release.xcconfig"; sourceTree = "<group>"; };
+		57F756558017352589C6CED3 /* Pods-BoostPocket.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BoostPocket.release.xcconfig"; path = "Target Support Files/Pods-BoostPocket/Pods-BoostPocket.release.xcconfig"; sourceTree = "<group>"; };
 		5C3DAF2D2566576000178EA0 /* CountryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryListViewController.swift; sourceTree = "<group>"; };
 		5C3DAF2E2566576000178EA0 /* CountryListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CountryListViewController.xib; sourceTree = "<group>"; };
 		5C3DAF3325665F0200178EA0 /* CountryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryCell.swift; sourceTree = "<group>"; };
 		5C3DAF3425665F0200178EA0 /* CountryCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CountryCell.xib; sourceTree = "<group>"; };
 		5C3DAF3925666A8000178EA0 /* TravelDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TravelDetail.storyboard; sourceTree = "<group>"; };
 		5C3DAF3D25666B4D00178EA0 /* TravelProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelProfileViewController.swift; sourceTree = "<group>"; };
+		81FEEDDEA3FA0D3B4F97EE2F /* Pods_BoostPocketTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BoostPocketTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9381276269F50AEF5C02E72C /* Pods-BoostPocket.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BoostPocket.debug.xcconfig"; path = "Target Support Files/Pods-BoostPocket/Pods-BoostPocket.debug.xcconfig"; sourceTree = "<group>"; };
+		9572F976256B5397003049CB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		95A42E7625664DBE0007810C /* BoostPocket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoostPocket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95A42E7925664DBE0007810C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95A42E7B25664DBE0007810C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -52,6 +61,7 @@
 		95A42E8F25664DC40007810C /* BoostPocketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoostPocketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		95A42E9325664DC40007810C /* BoostPocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoostPocketTests.swift; sourceTree = "<group>"; };
 		95A42E9525664DC40007810C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E2D16BE855D0105455137550 /* Pods-BoostPocketTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BoostPocketTests.debug.xcconfig"; path = "Target Support Files/Pods-BoostPocketTests/Pods-BoostPocketTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3725D4AFE6D2AE5B6A21D483 /* Pods_BoostPocket.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -66,18 +77,31 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				470EEBDB802C6552ECB4E189 /* Pods_BoostPocketTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		412BCF7739918A83178FE6E3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				05B97464333E742D61CD6648 /* Pods_BoostPocket.framework */,
+				81FEEDDEA3FA0D3B4F97EE2F /* Pods_BoostPocketTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		95A42E6D25664DBE0007810C = {
 			isa = PBXGroup;
 			children = (
+				9572F976256B5397003049CB /* .swiftlint.yml */,
 				95A42E7825664DBE0007810C /* BoostPocket */,
 				95A42E9225664DC40007810C /* BoostPocketTests */,
 				95A42E7725664DBE0007810C /* Products */,
+				975CDBB5924A01ABC7FC0012 /* Pods */,
+				412BCF7739918A83178FE6E3 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -120,6 +144,17 @@
 			path = BoostPocketTests;
 			sourceTree = "<group>";
 		};
+		975CDBB5924A01ABC7FC0012 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9381276269F50AEF5C02E72C /* Pods-BoostPocket.debug.xcconfig */,
+				57F756558017352589C6CED3 /* Pods-BoostPocket.release.xcconfig */,
+				E2D16BE855D0105455137550 /* Pods-BoostPocketTests.debug.xcconfig */,
+				460E2B0DBA1F49A0D275F156 /* Pods-BoostPocketTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -127,9 +162,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 95A42E9825664DC40007810C /* Build configuration list for PBXNativeTarget "BoostPocket" */;
 			buildPhases = (
+				B55ECE59FADBC4DD39B5B4A0 /* [CP] Check Pods Manifest.lock */,
 				95A42E7225664DBE0007810C /* Sources */,
 				95A42E7325664DBE0007810C /* Frameworks */,
 				95A42E7425664DBE0007810C /* Resources */,
+				9572F975256B5326003049CB /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -144,6 +181,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 95A42E9B25664DC40007810C /* Build configuration list for PBXNativeTarget "BoostPocketTests" */;
 			buildPhases = (
+				863277859F00183827011288 /* [CP] Check Pods Manifest.lock */,
 				95A42E8B25664DC40007810C /* Sources */,
 				95A42E8C25664DC40007810C /* Frameworks */,
 				95A42E8D25664DC40007810C /* Resources */,
@@ -204,6 +242,7 @@
 				5C3DAF3625665F0200178EA0 /* CountryCell.xib in Resources */,
 				95A42E8925664DC40007810C /* LaunchScreen.storyboard in Resources */,
 				5C3DAF302566576000178EA0 /* CountryListViewController.xib in Resources */,
+				9572F977256B5397003049CB /* .swiftlint.yml in Resources */,
 				95A42E8625664DC40007810C /* Assets.xcassets in Resources */,
 				95A42E8125664DBE0007810C /* Main.storyboard in Resources */,
 				5C3DAF3A25666A8000178EA0 /* TravelDetail.storyboard in Resources */,
@@ -218,6 +257,70 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		863277859F00183827011288 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BoostPocketTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9572F975256B5326003049CB /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint\n";
+		};
+		B55ECE59FADBC4DD39B5B4A0 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BoostPocket-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		95A42E7225664DBE0007810C /* Sources */ = {
@@ -388,6 +491,7 @@
 		};
 		95A42E9925664DC40007810C /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9381276269F50AEF5C02E72C /* Pods-BoostPocket.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -406,6 +510,7 @@
 		};
 		95A42E9A25664DC40007810C /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 57F756558017352589C6CED3 /* Pods-BoostPocket.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -424,6 +529,7 @@
 		};
 		95A42E9C25664DC40007810C /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E2D16BE855D0105455137550 /* Pods-BoostPocketTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -446,6 +552,7 @@
 		};
 		95A42E9D25664DC40007810C /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 460E2B0DBA1F49A0D275F156 /* Pods-BoostPocketTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";

--- a/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
+++ b/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 				95A42E7325664DBE0007810C /* Frameworks */,
 				95A42E7425664DBE0007810C /* Resources */,
 				9572F975256B5326003049CB /* ShellScript */,
+				AEF4ECA62A7CFEDFFDC5ACCA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -297,6 +298,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint\n";
+		};
+		AEF4ECA62A7CFEDFFDC5ACCA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-BoostPocket/Pods-BoostPocket-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-BoostPocket/Pods-BoostPocket-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BoostPocket/Pods-BoostPocket-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		B55ECE59FADBC4DD39B5B4A0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
+++ b/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -16,6 +16,13 @@
 		5C3DAF3A25666A8000178EA0 /* TravelDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5C3DAF3925666A8000178EA0 /* TravelDetail.storyboard */; };
 		5C3DAF3E25666B4D00178EA0 /* TravelProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3DAF3D25666B4D00178EA0 /* TravelProfileViewController.swift */; };
 		9572F977256B5397003049CB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 9572F976256B5397003049CB /* .swiftlint.yml */; };
+		9572F986256B54E4003049CB /* NetworkManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9572F97D256B54E4003049CB /* NetworkManager.framework */; };
+		9572F98D256B54E4003049CB /* NetworkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9572F98C256B54E4003049CB /* NetworkManagerTests.swift */; };
+		9572F98F256B54E4003049CB /* NetworkManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9572F97F256B54E4003049CB /* NetworkManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9572F992256B54E4003049CB /* NetworkManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9572F97D256B54E4003049CB /* NetworkManager.framework */; };
+		9572F994256B54E4003049CB /* NetworkManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9572F97D256B54E4003049CB /* NetworkManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9572F99C256B552E003049CB /* DataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9572F99B256B552E003049CB /* DataLoader.swift */; };
+		9572F99D256B552E003049CB /* DataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9572F99B256B552E003049CB /* DataLoader.swift */; };
 		95A42E7A25664DBE0007810C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E7925664DBE0007810C /* AppDelegate.swift */; };
 		95A42E7C25664DBE0007810C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E7B25664DBE0007810C /* SceneDelegate.swift */; };
 		95A42E7E25664DBE0007810C /* TravelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E7D25664DBE0007810C /* TravelListViewController.swift */; };
@@ -27,6 +34,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		9572F987256B54E4003049CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 95A42E6E25664DBE0007810C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9572F97C256B54E4003049CB;
+			remoteInfo = NetworkManager;
+		};
+		9572F989256B54E4003049CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 95A42E6E25664DBE0007810C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 95A42E7525664DBE0007810C;
+			remoteInfo = BoostPocket;
+		};
+		9572F990256B54E4003049CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 95A42E6E25664DBE0007810C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9572F97C256B54E4003049CB;
+			remoteInfo = NetworkManager;
+		};
 		95A42E9025664DC40007810C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 95A42E6E25664DBE0007810C /* Project object */;
@@ -35,6 +63,20 @@
 			remoteInfo = BoostPocket;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9572F993256B54E4003049CB /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9572F994256B54E4003049CB /* NetworkManager.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		05B97464333E742D61CD6648 /* Pods_BoostPocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BoostPocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -49,6 +91,13 @@
 		81FEEDDEA3FA0D3B4F97EE2F /* Pods_BoostPocketTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BoostPocketTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9381276269F50AEF5C02E72C /* Pods-BoostPocket.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BoostPocket.debug.xcconfig"; path = "Target Support Files/Pods-BoostPocket/Pods-BoostPocket.debug.xcconfig"; sourceTree = "<group>"; };
 		9572F976256B5397003049CB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		9572F97D256B54E4003049CB /* NetworkManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NetworkManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9572F97F256B54E4003049CB /* NetworkManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkManager.h; sourceTree = "<group>"; };
+		9572F980256B54E4003049CB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9572F985256B54E4003049CB /* NetworkManagerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NetworkManagerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9572F98C256B54E4003049CB /* NetworkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerTests.swift; sourceTree = "<group>"; };
+		9572F98E256B54E4003049CB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9572F99B256B552E003049CB /* DataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataLoader.swift; sourceTree = "<group>"; };
 		95A42E7625664DBE0007810C /* BoostPocket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoostPocket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95A42E7925664DBE0007810C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95A42E7B25664DBE0007810C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -65,11 +114,27 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		9572F97A256B54E4003049CB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9572F982256B54E4003049CB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9572F986256B54E4003049CB /* NetworkManager.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		95A42E7325664DBE0007810C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				3725D4AFE6D2AE5B6A21D483 /* Pods_BoostPocket.framework in Frameworks */,
+				9572F992256B54E4003049CB /* NetworkManager.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,12 +158,33 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		9572F97E256B54E4003049CB /* NetworkManager */ = {
+			isa = PBXGroup;
+			children = (
+				9572F97F256B54E4003049CB /* NetworkManager.h */,
+				9572F980256B54E4003049CB /* Info.plist */,
+				9572F99B256B552E003049CB /* DataLoader.swift */,
+			);
+			path = NetworkManager;
+			sourceTree = "<group>";
+		};
+		9572F98B256B54E4003049CB /* NetworkManagerTests */ = {
+			isa = PBXGroup;
+			children = (
+				9572F98C256B54E4003049CB /* NetworkManagerTests.swift */,
+				9572F98E256B54E4003049CB /* Info.plist */,
+			);
+			path = NetworkManagerTests;
+			sourceTree = "<group>";
+		};
 		95A42E6D25664DBE0007810C = {
 			isa = PBXGroup;
 			children = (
 				9572F976256B5397003049CB /* .swiftlint.yml */,
 				95A42E7825664DBE0007810C /* BoostPocket */,
 				95A42E9225664DC40007810C /* BoostPocketTests */,
+				9572F97E256B54E4003049CB /* NetworkManager */,
+				9572F98B256B54E4003049CB /* NetworkManagerTests */,
 				95A42E7725664DBE0007810C /* Products */,
 				975CDBB5924A01ABC7FC0012 /* Pods */,
 				412BCF7739918A83178FE6E3 /* Frameworks */,
@@ -110,6 +196,8 @@
 			children = (
 				95A42E7625664DBE0007810C /* BoostPocket.app */,
 				95A42E8F25664DC40007810C /* BoostPocketTests.xctest */,
+				9572F97D256B54E4003049CB /* NetworkManager.framework */,
+				9572F985256B54E4003049CB /* NetworkManagerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -157,7 +245,55 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		9572F978256B54E4003049CB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9572F98F256B54E4003049CB /* NetworkManager.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		9572F97C256B54E4003049CB /* NetworkManager */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9572F999256B54E4003049CB /* Build configuration list for PBXNativeTarget "NetworkManager" */;
+			buildPhases = (
+				9572F978256B54E4003049CB /* Headers */,
+				9572F979256B54E4003049CB /* Sources */,
+				9572F97A256B54E4003049CB /* Frameworks */,
+				9572F97B256B54E4003049CB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NetworkManager;
+			productName = NetworkManager;
+			productReference = 9572F97D256B54E4003049CB /* NetworkManager.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9572F984256B54E4003049CB /* NetworkManagerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9572F99A256B54E4003049CB /* Build configuration list for PBXNativeTarget "NetworkManagerTests" */;
+			buildPhases = (
+				9572F981256B54E4003049CB /* Sources */,
+				9572F982256B54E4003049CB /* Frameworks */,
+				9572F983256B54E4003049CB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9572F988256B54E4003049CB /* PBXTargetDependency */,
+				9572F98A256B54E4003049CB /* PBXTargetDependency */,
+			);
+			name = NetworkManagerTests;
+			productName = NetworkManagerTests;
+			productReference = 9572F985256B54E4003049CB /* NetworkManagerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		95A42E7525664DBE0007810C /* BoostPocket */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 95A42E9825664DC40007810C /* Build configuration list for PBXNativeTarget "BoostPocket" */;
@@ -168,10 +304,12 @@
 				95A42E7425664DBE0007810C /* Resources */,
 				9572F975256B5326003049CB /* ShellScript */,
 				AEF4ECA62A7CFEDFFDC5ACCA /* [CP] Embed Pods Frameworks */,
+				9572F993256B54E4003049CB /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				9572F991256B54E4003049CB /* PBXTargetDependency */,
 			);
 			name = BoostPocket;
 			productName = BoostPocket;
@@ -207,6 +345,14 @@
 				LastUpgradeCheck = 1160;
 				ORGANIZATIONNAME = BoostPocket;
 				TargetAttributes = {
+					9572F97C256B54E4003049CB = {
+						CreatedOnToolsVersion = 11.6;
+						LastSwiftMigration = 1160;
+					};
+					9572F984256B54E4003049CB = {
+						CreatedOnToolsVersion = 11.6;
+						TestTargetID = 95A42E7525664DBE0007810C;
+					};
 					95A42E7525664DBE0007810C = {
 						CreatedOnToolsVersion = 11.6;
 					};
@@ -231,11 +377,27 @@
 			targets = (
 				95A42E7525664DBE0007810C /* BoostPocket */,
 				95A42E8E25664DC40007810C /* BoostPocketTests */,
+				9572F97C256B54E4003049CB /* NetworkManager */,
+				9572F984256B54E4003049CB /* NetworkManagerTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		9572F97B256B54E4003049CB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9572F983256B54E4003049CB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		95A42E7425664DBE0007810C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -341,6 +503,23 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		9572F979256B54E4003049CB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9572F99C256B552E003049CB /* DataLoader.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9572F981256B54E4003049CB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9572F99D256B552E003049CB /* DataLoader.swift in Sources */,
+				9572F98D256B54E4003049CB /* NetworkManagerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		95A42E7225664DBE0007810C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -366,6 +545,21 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		9572F988256B54E4003049CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9572F97C256B54E4003049CB /* NetworkManager */;
+			targetProxy = 9572F987256B54E4003049CB /* PBXContainerItemProxy */;
+		};
+		9572F98A256B54E4003049CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 95A42E7525664DBE0007810C /* BoostPocket */;
+			targetProxy = 9572F989256B54E4003049CB /* PBXContainerItemProxy */;
+		};
+		9572F991256B54E4003049CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9572F97C256B54E4003049CB /* NetworkManager */;
+			targetProxy = 9572F990256B54E4003049CB /* PBXContainerItemProxy */;
+		};
 		95A42E9125664DC40007810C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 95A42E7525664DBE0007810C /* BoostPocket */;
@@ -393,6 +587,103 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		9572F995256B54E4003049CB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = NetworkManager/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = BoostPocket.NetworkManager;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		9572F996256B54E4003049CB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = NetworkManager/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = BoostPocket.NetworkManager;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		9572F997256B54E4003049CB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = NetworkManagerTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = BoostPocket.NetworkManagerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BoostPocket.app/BoostPocket";
+			};
+			name = Debug;
+		};
+		9572F998256B54E4003049CB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = NetworkManagerTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = BoostPocket.NetworkManagerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BoostPocket.app/BoostPocket";
+			};
+			name = Release;
+		};
 		95A42E9625664DC40007810C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -511,6 +802,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9381276269F50AEF5C02E72C /* Pods-BoostPocket.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
@@ -530,6 +822,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 57F756558017352589C6CED3 /* Pods-BoostPocket.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
@@ -594,6 +887,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		9572F999256B54E4003049CB /* Build configuration list for PBXNativeTarget "NetworkManager" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9572F995256B54E4003049CB /* Debug */,
+				9572F996256B54E4003049CB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9572F99A256B54E4003049CB /* Build configuration list for PBXNativeTarget "NetworkManagerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9572F997256B54E4003049CB /* Debug */,
+				9572F998256B54E4003049CB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		95A42E7125664DBE0007810C /* Build configuration list for PBXProject "BoostPocket" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/BoostPocket/BoostPocket.xcworkspace/contents.xcworkspacedata
+++ b/BoostPocket/BoostPocket.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:BoostPocket.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/BoostPocket/BoostPocket.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BoostPocket/BoostPocket.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BoostPocket/BoostPocket/AppDelegate.swift
+++ b/BoostPocket/BoostPocket/AppDelegate.swift
@@ -12,8 +12,6 @@ import CoreData
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
@@ -79,4 +77,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
-

--- a/BoostPocket/BoostPocket/SceneDelegate.swift
+++ b/BoostPocket/BoostPocket/SceneDelegate.swift
@@ -12,7 +12,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -51,6 +50,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 
-
 }
-

--- a/BoostPocket/BoostPocket/TravelListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelListViewController.swift
@@ -15,7 +15,6 @@ class TravelListViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
-
     @IBAction func newTravelButtonTapped(_ sender: Any) {
         let countryListVC = CountryListViewController.init(nibName: "CountryListViewController", bundle: nil)
         countryListVC.doneButtonHandler = {

--- a/BoostPocket/BoostPocket/TravelListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelListViewController.swift
@@ -28,6 +28,4 @@ class TravelListViewController: UIViewController {
         self.present(navigationController, animated: true, completion: nil)
     }
     
-    
 }
-

--- a/BoostPocket/BoostPocket/TravelProfileViewController.swift
+++ b/BoostPocket/BoostPocket/TravelProfileViewController.swift
@@ -15,16 +15,5 @@ class TravelProfileViewController: UIViewController {
 
         // Do any additional setup after loading the view.
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/BoostPocket/BoostPocket/ViewController.swift
+++ b/BoostPocket/BoostPocket/ViewController.swift
@@ -15,11 +15,9 @@ class TravelListViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
-
     @IBAction func newTravelButtonTapped(_ sender: Any) {
         let countryListVC = CountryListViewController.init(nibName: "CountryListViewController", bundle: nil)
         let navigationController = UINavigationController(rootViewController: countryListVC)
         self.present(navigationController, animated: true, completion: nil)
     }
 }
-

--- a/BoostPocket/NetworkManager/DataLoader.swift
+++ b/BoostPocket/NetworkManager/DataLoader.swift
@@ -1,0 +1,54 @@
+//
+//  DataLoader.swift
+//  BoostPocket
+//
+//  Created by sihyung you on 2020/11/23.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+import Foundation
+
+struct ExchangeRate: Codable {
+    let rates: [String: Float]
+    let base: String
+    let date: String
+}
+
+protocol DataLoadable {
+    var requestURL: URL? { get }
+    func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate?, NetworkError>) -> Void)
+    func converToURL(url: String) -> URL?
+}
+
+//class DataLoader: DataLoadable {
+//    var requestURL: URL?
+//
+//    func requestExchangeRate(url: URL, completion: @escaping (ExchangeRate?) -> Void) {
+//        // 실제 URLSession을 통한 HTTP Request
+//    }
+//
+//}
+
+class DataLoaderStub: DataLoadable {
+    
+    var requestURL: URL?
+    
+    func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate?, NetworkError>) -> Void) {
+        // 성공/실패에 대한 completion만 넘겨주기
+        // 혹은 request param에 대한 일치여부만 확인
+    }
+    
+    func converToURL(url: String) -> URL? {
+        guard let validURL = URL(string: url) else {
+            return nil
+        }
+        
+        return validURL
+    }
+}
+
+public enum NetworkError: Error {
+    case invalidURL(String)
+    case decodingError(Error)
+    case imageIsNil
+}

--- a/BoostPocket/NetworkManager/DataLoader.swift
+++ b/BoostPocket/NetworkManager/DataLoader.swift
@@ -8,47 +8,79 @@
 
 import Foundation
 
-struct ExchangeRate: Codable {
-    let rates: [String: Float]
-    let base: String
-    let date: String
-}
-
 protocol DataLoadable {
+    var session: URLSession { get }
     var requestURL: URL? { get }
-    func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate?, NetworkError>) -> Void)
+    func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate, NetworkError>) -> Void)
     func converToURL(url: String) -> URL?
 }
 
-//class DataLoader: DataLoadable {
-//    var requestURL: URL?
-//
-//    func requestExchangeRate(url: URL, completion: @escaping (ExchangeRate?) -> Void) {
-//        // 실제 URLSession을 통한 HTTP Request
-//    }
-//
-//}
-
-class DataLoaderStub: DataLoadable {
-    
+class DataLoader: DataLoadable {
+    var session: URLSession
     var requestURL: URL?
     
-    func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate?, NetworkError>) -> Void) {
-        // 성공/실패에 대한 completion만 넘겨주기
-        // 혹은 request param에 대한 일치여부만 확인
+    init(session: URLSession) {
+        self.session = session
+    }
+    
+    func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate, NetworkError>) -> Void) {
+        guard let requestURL = converToURL(url: url) else {
+            completion(.failure(.invalidURL("유효하지 않은 주소입니다.")))
+            return
+        }
+        
+        // 실제 요청
+        session.dataTask(with: requestURL) { data, _, error in
+            guard error == nil, let data = data else {
+                completion(.failure(.networkError(error!)))
+                return
+            }
+            
+            do {
+                let jsonDecoder = JSONDecoder()
+                let exchangeRates = try jsonDecoder.decode(ExchangeRate.self, from: data)
+                completion(.success(exchangeRates))
+            } catch {
+                completion(.failure(.decodingError(error)))
+            }
+        }.resume()
     }
     
     func converToURL(url: String) -> URL? {
-        guard let validURL = URL(string: url) else {
-            return nil
-        }
+        guard let validURL = URL(string: url) else { return nil }
+        
+        return validURL
+    }
+}
+
+class DataLoaderStub: DataLoadable {
+    var session: URLSession
+    var requestURL: URL?
+    
+    init(session: URLSession) {
+        self.session = session
+    }
+    
+    func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate, NetworkError>) -> Void) {
+        requestURL = converToURL(url: url)
+    }
+    
+    func converToURL(url: String) -> URL? {
+        guard let validURL = URL(string: url) else { return nil }
         
         return validURL
     }
 }
 
 public enum NetworkError: Error {
+    case networkError(Error)
     case invalidURL(String)
     case decodingError(Error)
     case imageIsNil
+}
+
+struct ExchangeRate: Codable {
+    let rates: [String: Float]
+    let base: String
+    let date: String
 }

--- a/BoostPocket/NetworkManager/Info.plist
+++ b/BoostPocket/NetworkManager/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/BoostPocket/NetworkManager/NetworkManager.h
+++ b/BoostPocket/NetworkManager/NetworkManager.h
@@ -1,0 +1,19 @@
+//
+//  NetworkManager.h
+//  NetworkManager
+//
+//  Created by sihyung you on 2020/11/23.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for NetworkManager.
+FOUNDATION_EXPORT double NetworkManagerVersionNumber;
+
+//! Project version string for NetworkManager.
+FOUNDATION_EXPORT const unsigned char NetworkManagerVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <NetworkManager/PublicHeader.h>
+
+

--- a/BoostPocket/NetworkManagerTests/Info.plist
+++ b/BoostPocket/NetworkManagerTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/BoostPocket/NetworkManagerTests/NetworkManagerTests.swift
+++ b/BoostPocket/NetworkManagerTests/NetworkManagerTests.swift
@@ -1,0 +1,36 @@
+//
+//  NetworkManagerTests.swift
+//  NetworkManagerTests
+//
+//  Created by sihyung you on 2020/11/23.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+import XCTest
+@testable import NetworkManager
+
+class NetworkManagerTests: XCTestCase {
+    
+    var dataLoaderStub: DataLoadable!
+    
+    override func setUpWithError() throws {
+        dataLoaderStub = DataLoaderStub()
+    }
+
+    override func tearDownWithError() throws {
+        dataLoaderStub = nil
+    }
+    
+    func test_get_request_withURL() {
+        let url = "https://mockurl"
+        dataLoaderStub.requestExchangeRate(url: url) { _ in }
+        
+        XCTAssert(dataLoaderStub.requestURL?.absoluteString == url)
+        
+    }
+    
+    func test_convert_to_URL() {
+        let url = "https://mockurl"
+        XCTAssertEqual(dataLoaderStub.converToURL(url: url)?.absoluteString, url)
+    }
+}

--- a/BoostPocket/NetworkManagerTests/NetworkManagerTests.swift
+++ b/BoostPocket/NetworkManagerTests/NetworkManagerTests.swift
@@ -12,25 +12,42 @@ import XCTest
 class NetworkManagerTests: XCTestCase {
     
     var dataLoaderStub: DataLoadable!
+    var session: URLSession!
     
     override func setUpWithError() throws {
-        dataLoaderStub = DataLoaderStub()
+        session = URLSession.shared
+        dataLoaderStub = DataLoaderStub(session: session)
     }
 
     override func tearDownWithError() throws {
+        session = nil
         dataLoaderStub = nil
     }
     
+    func test_dataLoader_session() {
+        // then
+        XCTAssertEqual(dataLoaderStub.session, session)
+    }
+    
     func test_get_request_withURL() {
+        // given
         let url = "https://mockurl"
+        
+        // when
         dataLoaderStub.requestExchangeRate(url: url) { _ in }
         
+        // then
         XCTAssert(dataLoaderStub.requestURL?.absoluteString == url)
-        
     }
     
     func test_convert_to_URL() {
+        // given
         let url = "https://mockurl"
-        XCTAssertEqual(dataLoaderStub.converToURL(url: url)?.absoluteString, url)
+        
+        // when
+        let isValidURL = dataLoaderStub.converToURL(url: url)
+        
+        // then
+        XCTAssertEqual(isValidURL?.absoluteString, url)
     }
 }

--- a/BoostPocket/Podfile
+++ b/BoostPocket/Podfile
@@ -7,6 +7,7 @@ target 'BoostPocket' do
 
   # Pods for BoostPocket
   pod 'SwiftLint'
+  pod 'FlagKit'
 
   target 'BoostPocketTests' do
     inherit! :search_paths

--- a/BoostPocket/Podfile
+++ b/BoostPocket/Podfile
@@ -1,0 +1,16 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'BoostPocket' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for BoostPocket
+  pod 'SwiftLint'
+
+  target 'BoostPocketTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+end

--- a/BoostPocket/Podfile.lock
+++ b/BoostPocket/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - SwiftLint (0.41.0)
+
+DEPENDENCIES:
+  - SwiftLint
+
+SPEC REPOS:
+  trunk:
+    - SwiftLint
+
+SPEC CHECKSUMS:
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+
+PODFILE CHECKSUM: 4739b16459b48c1c06541b061728f6b096e531fa
+
+COCOAPODS: 1.9.3

--- a/BoostPocket/Podfile.lock
+++ b/BoostPocket/Podfile.lock
@@ -1,16 +1,20 @@
 PODS:
+  - FlagKit (2.2)
   - SwiftLint (0.41.0)
 
 DEPENDENCIES:
+  - FlagKit
   - SwiftLint
 
 SPEC REPOS:
   trunk:
+    - FlagKit
     - SwiftLint
 
 SPEC CHECKSUMS:
+  FlagKit: eca7dc89064b0c986302ba9acefad1bf80a435b1
   SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
 
-PODFILE CHECKSUM: 4739b16459b48c1c06541b061728f6b096e531fa
+PODFILE CHECKSUM: b23a7f7122528f0ad7ac529b7156ff5bfa944a34
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
### Issue Number
Close #17 

### 변경사항
SwiftLint 추가
Flagkit Pod 추가
네트워크 모델 테스트코드 작성
환율 API를 위한 네트워크 요청 함수 구현

### 새로운 기능
Lint warning을 통해 문법오류를 잡아낼 수 있다.
Flagkit을 통해 국가 이미지를 불러올 수 있다.
네트워크 연결이 가능하다.

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
