### PR TITLE
국가 정보 저장 구현

### DIFF
--- a/BoostPocket/NetworkManager/DataLoader.swift
+++ b/BoostPocket/NetworkManager/DataLoader.swift
@@ -9,21 +9,22 @@
 import Foundation
 
 protocol DataLoadable {
+    
     var session: URLSession { get }
     var requestURL: URL? { get }
     func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate, NetworkError>) -> Void)
     func converToURL(url: String) -> URL?
 }
 
-class DataLoader: DataLoadable {
+public class DataLoader: DataLoadable {
     var session: URLSession
     var requestURL: URL?
     
-    init(session: URLSession) {
+    public init(session: URLSession) {
         self.session = session
     }
     
-    func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate, NetworkError>) -> Void) {
+    public func requestExchangeRate(url: String, completion: @escaping (Result<ExchangeRate, NetworkError>) -> Void) {
         guard let requestURL = converToURL(url: url) else {
             completion(.failure(.invalidURL("유효하지 않은 주소입니다.")))
             return
@@ -46,7 +47,7 @@ class DataLoader: DataLoadable {
         }.resume()
     }
     
-    func converToURL(url: String) -> URL? {
+    public func converToURL(url: String) -> URL? {
         guard let validURL = URL(string: url) else { return nil }
         
         return validURL
@@ -76,11 +77,11 @@ public enum NetworkError: Error {
     case networkError(Error)
     case invalidURL(String)
     case decodingError(Error)
-    case imageIsNil
+    case imageIsNil(Error)
 }
 
-struct ExchangeRate: Codable {
-    let rates: [String: Float]
-    let base: String
-    let date: String
+public struct ExchangeRate: Codable {
+    public let rates: [String: Double]
+    public let base: String
+    public let date: String
 }


### PR DESCRIPTION
### Issue Number
Close #19

### 새로운 기능
- 환율 정보 api로 환율 정보를 받아옴
- 저장된 국가 정보가 없는 경우, Core data에 국가 정보 저장(국가명, 저장날짜, 국가 이미지, 환율 정보, 화폐코드)

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
