### PR TITLE
TravelListViewModel 메소드 구현

### DIFF
--- a/BoostPocket/BoostPocket/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/PersistenceManager.swift
@@ -107,6 +107,7 @@ class PersistenceManager: PersistenceManagable {
         newTravel.title = fetchedCountry.name
         newTravel.exchangeRate = fetchedCountry.exchangeRate
         newTravel.country = fetchedCountry
+        newTravel.startDate = Date()
         newTravel.id = UUID()
         newTravel.coverImage = Data() // TODO: - asset에 디폴트 이미지 넣어놓기
         
@@ -120,6 +121,9 @@ class PersistenceManager: PersistenceManagable {
         if T.self == Country.self {
             let nameSort = NSSortDescriptor(key: "name", ascending: true)
             request.sortDescriptors = [nameSort]
+        } else if T.self == Travel.self {
+            let startDateSort = NSSortDescriptor(key: "startDate", ascending: true)
+            request.sortDescriptors = [startDateSort]
         }
         
         do {

--- a/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
@@ -37,7 +37,7 @@ class TravelListViewModel: TravelListPresentable {
     func createTravel(countryName: String) -> TravelItemViewModel? {
         guard let createdTravel = travelProvider?.createTravel(countryName: countryName) else { return nil }
         let createdTravelItemViewModel = TravelItemViewModel(travel: createdTravel)
-        travels.append(createdTravelItemViewModel)
+        // travels.append(createdTravelItemViewModel)
         return createdTravelItemViewModel
     }
     

--- a/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
@@ -46,7 +46,7 @@ class TravelListViewModel: TravelListPresentable {
     }
     
     func numberOfItem() -> Int {
-        return 0
+        return travels.count
     }
     
 }

--- a/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
@@ -42,7 +42,7 @@ class TravelListViewModel: TravelListPresentable {
     }
     
     func cellForItemAt(path: IndexPath) -> TravelItemViewModel? {
-        return nil
+        return travels[path.row]
     }
     
     func numberOfItem() -> Int {

--- a/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
@@ -21,7 +21,13 @@ protocol TravelListPresentable {
 
 class TravelListViewModel: TravelListPresentable {
     
-    var travels: [TravelItemViewModel] = []
+    var travels: [TravelItemViewModel] = [] {
+        willSet {
+            DispatchQueue.main.async { [weak self] in
+                self?.didFetch?(newValue)
+            }
+        }
+    }
     var didFetch: (([TravelItemViewModel]) -> Void)?
     private weak var countryProvider: CountryProvidable?
     private weak var travelProvider: TravelProvidable?
@@ -32,12 +38,19 @@ class TravelListViewModel: TravelListPresentable {
     }
     
     func needFetchItems() {
+        guard let fetchedTravels = travelProvider?.fetchTravels() else { return }
+        travels.removeAll()
+        var newTravelItemViewModels: [TravelItemViewModel] = []
+        fetchedTravels.forEach { travel in
+            newTravelItemViewModels.append(TravelItemViewModel(travel: travel))
+        }
+        travels = newTravelItemViewModels
     }
     
     func createTravel(countryName: String) -> TravelItemViewModel? {
         guard let createdTravel = travelProvider?.createTravel(countryName: countryName) else { return nil }
         let createdTravelItemViewModel = TravelItemViewModel(travel: createdTravel)
-        // travels.append(createdTravelItemViewModel)
+        travels.append(createdTravelItemViewModel)
         return createdTravelItemViewModel
     }
     

--- a/BoostPocket/BoostPocket/TravelListScene/TravelViewModelTests.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelViewModelTests.swift
@@ -90,4 +90,15 @@ class TravelViewModelTests: XCTestCase {
         XCTAssertEqual(travelItem?.currencyCode, country?.currencyCode)
         XCTAssertEqual(travelItem?.exchangeRate, country?.exchangeRate)
     }
+    
+    func test_TravelListViewModel_numberOfItem() {
+        countryProvider.createCountry(name: "미국", lastUpdated: Date(), flagImage: Data(), exchangeRate: 3.29, currencyCode: "USD")
+        countryProvider.createCountry(name: "일본", lastUpdated: Date(), flagImage: Data(), exchangeRate: 12.1, currencyCode: "JPY")
+
+        travelListViewModel.createTravel(countryName: "대한민국")
+        travelListViewModel.createTravel(countryName: "미국")
+        travelListViewModel.createTravel(countryName: "일본")
+        
+        XCTAssertEqual(travelListViewModel.numberOfItem(), 3)
+    }
 }

--- a/BoostPocket/BoostPocket/TravelListScene/TravelViewModelTests.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelViewModelTests.swift
@@ -80,16 +80,30 @@ class TravelViewModelTests: XCTestCase {
         XCTAssertNotNil(createdTravel?.flagImage)
     }
     
-    func test_TravelListViewModel_cellForItemAt() {
-        travelListViewModel.createTravel(countryName: countryName)
+    func test_TravelListViewModel_needFetchItems() {
+        countryProvider.createCountry(name: "미국", lastUpdated: Date(), flagImage: Data(), exchangeRate: 3.29, currencyCode: "USD")
+        countryProvider.createCountry(name: "일본", lastUpdated: Date(), flagImage: Data(), exchangeRate: 12.1, currencyCode: "JPY")
         
-        let travelItem = travelListViewModel.cellForItemAt(path: IndexPath(row: 0, section: 0))
+        travelListViewModel.createTravel(countryName: "대한민국")
+        travelListViewModel.createTravel(countryName: "미국")
+        travelListViewModel.createTravel(countryName: "일본")
         
-        XCTAssertEqual(travelItem?.title, country?.name)
-        XCTAssertEqual(travelItem?.countryName, country?.name)
-        XCTAssertEqual(travelItem?.currencyCode, country?.currencyCode)
-        XCTAssertEqual(travelItem?.exchangeRate, country?.exchangeRate)
+        travelListViewModel.needFetchItems()
+        XCTAssertEqual(travelListViewModel.travels.count, 3)
+        XCTAssertEqual(travelListViewModel.travels.first?.title, "대한민국")
+        XCTAssertEqual(travelListViewModel.travels.last?.title, "일본")
     }
+    
+//    func test_TravelListViewModel_cellForItemAt() {
+//        travelListViewModel.createTravel(countryName: countryName)
+//
+//        let travelItem = travelListViewModel.cellForItemAt(path: IndexPath(row: 0, section: 0))
+//
+//        XCTAssertEqual(travelItem?.title, country?.name)
+//        XCTAssertEqual(travelItem?.countryName, country?.name)
+//        XCTAssertEqual(travelItem?.currencyCode, country?.currencyCode)
+//        XCTAssertEqual(travelItem?.exchangeRate, country?.exchangeRate)
+//    }
     
     func test_TravelListViewModel_numberOfItem() {
         countryProvider.createCountry(name: "미국", lastUpdated: Date(), flagImage: Data(), exchangeRate: 3.29, currencyCode: "USD")

--- a/BoostPocket/BoostPocket/TravelListScene/TravelViewModelTests.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelViewModelTests.swift
@@ -74,8 +74,8 @@ class TravelViewModelTests: XCTestCase {
         XCTAssertEqual(createdTravel?.currencyCode, country?.currencyCode)
         XCTAssertEqual(createdTravel?.exchangeRate, country?.exchangeRate)
         XCTAssertEqual(createdTravel?.budget, 0.0)
-        XCTAssertNil(createdTravel?.startDate)
         XCTAssertNil(createdTravel?.endDate)
+        XCTAssertNotNil(createdTravel?.startDate)
         XCTAssertNotNil(createdTravel?.coverImage)
         XCTAssertNotNil(createdTravel?.flagImage)
     }
@@ -84,9 +84,9 @@ class TravelViewModelTests: XCTestCase {
         countryProvider.createCountry(name: "미국", lastUpdated: Date(), flagImage: Data(), exchangeRate: 3.29, currencyCode: "USD")
         countryProvider.createCountry(name: "일본", lastUpdated: Date(), flagImage: Data(), exchangeRate: 12.1, currencyCode: "JPY")
         
-        travelListViewModel.createTravel(countryName: "대한민국")
-        travelListViewModel.createTravel(countryName: "미국")
-        travelListViewModel.createTravel(countryName: "일본")
+        XCTAssertNotNil(travelProvider.createTravel(countryName: "대한민국"))
+        XCTAssertNotNil(travelProvider.createTravel(countryName: "미국"))
+        XCTAssertNotNil(travelProvider.createTravel(countryName: "일본"))
         
         travelListViewModel.needFetchItems()
         XCTAssertEqual(travelListViewModel.travels.count, 3)
@@ -94,16 +94,16 @@ class TravelViewModelTests: XCTestCase {
         XCTAssertEqual(travelListViewModel.travels.last?.title, "일본")
     }
     
-//    func test_TravelListViewModel_cellForItemAt() {
-//        travelListViewModel.createTravel(countryName: countryName)
-//
-//        let travelItem = travelListViewModel.cellForItemAt(path: IndexPath(row: 0, section: 0))
-//
-//        XCTAssertEqual(travelItem?.title, country?.name)
-//        XCTAssertEqual(travelItem?.countryName, country?.name)
-//        XCTAssertEqual(travelItem?.currencyCode, country?.currencyCode)
-//        XCTAssertEqual(travelItem?.exchangeRate, country?.exchangeRate)
-//    }
+    func test_TravelListViewModel_cellForItemAt() {
+        travelListViewModel.createTravel(countryName: countryName)
+
+        let travelItem = travelListViewModel.cellForItemAt(path: IndexPath(row: 0, section: 0))
+
+        XCTAssertEqual(travelItem?.title, country?.name)
+        XCTAssertEqual(travelItem?.countryName, country?.name)
+        XCTAssertEqual(travelItem?.currencyCode, country?.currencyCode)
+        XCTAssertEqual(travelItem?.exchangeRate, country?.exchangeRate)
+    }
     
     func test_TravelListViewModel_numberOfItem() {
         countryProvider.createCountry(name: "미국", lastUpdated: Date(), flagImage: Data(), exchangeRate: 3.29, currencyCode: "USD")

--- a/BoostPocket/BoostPocket/TravelListScene/TravelViewModelTests.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelViewModelTests.swift
@@ -79,4 +79,15 @@ class TravelViewModelTests: XCTestCase {
         XCTAssertNotNil(createdTravel?.coverImage)
         XCTAssertNotNil(createdTravel?.flagImage)
     }
+    
+    func test_TravelListViewModel_cellForItemAt() {
+        travelListViewModel.createTravel(countryName: countryName)
+        
+        let travelItem = travelListViewModel.cellForItemAt(path: IndexPath(row: 0, section: 0))
+        
+        XCTAssertEqual(travelItem?.title, country?.name)
+        XCTAssertEqual(travelItem?.countryName, country?.name)
+        XCTAssertEqual(travelItem?.currencyCode, country?.currencyCode)
+        XCTAssertEqual(travelItem?.exchangeRate, country?.exchangeRate)
+    }
 }


### PR DESCRIPTION
### Issue Number
#28 

### 변경사항
- CountryListViewModel, TravelListViewModel fetch 시점 변경

### 새로운 기능
- TravelListViewModel 테스트 및 메소드 구현
    - numberOfItem, cellForItemAt, needFetchItems
- persistenceManager의 travel fetch 시 startDate를 기준으로 정렬하도록 구현

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
