### PR TITLE
CoreData에서 Travel Update 기능 구현

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -20,3 +20,5 @@ jobs:
     - name: Run BoostPocketTests
       run: xcodebuild test -workspace BoostPocket/BoostPocket.xcworkspace -scheme BoostPocketTests -destination 'platform=iOS Simulator,name=iPhone 11'
 
+    - name: Run NetworkManagerTests
+      run: xcodebuild test -workspace BoostPocket/BoostPocket.xcworkspace -scheme NetworkManagerTests -destination 'platform=iOS Simulator,name=iPhone 11'

--- a/BoostPocket/BoostPocket.xcodeproj/xcshareddata/xcschemes/BoostPocket.xcscheme
+++ b/BoostPocket/BoostPocket.xcodeproj/xcshareddata/xcschemes/BoostPocket.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95A42E7525664DBE0007810C"
+               BuildableName = "BoostPocket.app"
+               BlueprintName = "BoostPocket"
+               ReferencedContainer = "container:BoostPocket.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95A42E8E25664DC40007810C"
+               BuildableName = "BoostPocketTests.xctest"
+               BlueprintName = "BoostPocketTests"
+               ReferencedContainer = "container:BoostPocket.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9572F984256B54E4003049CB"
+               BuildableName = "NetworkManagerTests.xctest"
+               BlueprintName = "NetworkManagerTests"
+               ReferencedContainer = "container:BoostPocket.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95A42E7525664DBE0007810C"
+            BuildableName = "BoostPocket.app"
+            BlueprintName = "BoostPocket"
+            ReferencedContainer = "container:BoostPocket.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95A42E7525664DBE0007810C"
+            BuildableName = "BoostPocket.app"
+            BlueprintName = "BoostPocket"
+            ReferencedContainer = "container:BoostPocket.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BoostPocket/BoostPocket.xcodeproj/xcshareddata/xcschemes/BoostPocketTests.xcscheme
+++ b/BoostPocket/BoostPocket.xcodeproj/xcshareddata/xcschemes/BoostPocketTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95A42E8E25664DC40007810C"
+               BuildableName = "BoostPocketTests.xctest"
+               BlueprintName = "BoostPocketTests"
+               ReferencedContainer = "container:BoostPocket.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BoostPocket/BoostPocket.xcodeproj/xcshareddata/xcschemes/NetworkManager.xcscheme
+++ b/BoostPocket/BoostPocket.xcodeproj/xcshareddata/xcschemes/NetworkManager.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9572F97C256B54E4003049CB"
+               BuildableName = "NetworkManager.framework"
+               BlueprintName = "NetworkManager"
+               ReferencedContainer = "container:BoostPocket.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9572F97C256B54E4003049CB"
+            BuildableName = "NetworkManager.framework"
+            BlueprintName = "NetworkManager"
+            ReferencedContainer = "container:BoostPocket.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BoostPocket/BoostPocket.xcodeproj/xcshareddata/xcschemes/NetworkManagerTests.xcscheme
+++ b/BoostPocket/BoostPocket.xcodeproj/xcshareddata/xcschemes/NetworkManagerTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9572F984256B54E4003049CB"
+               BuildableName = "NetworkManagerTests.xctest"
+               BlueprintName = "NetworkManagerTests"
+               ReferencedContainer = "container:BoostPocket.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BoostPocket/BoostPocket/CountryListScene/CountryProvider.swift
+++ b/BoostPocket/BoostPocket/CountryListScene/CountryProvider.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import CoreData
 
 protocol CountryProvidable: AnyObject {
     var countries: [Country] { get }

--- a/BoostPocket/BoostPocket/Models/DataModelInfo.swift
+++ b/BoostPocket/BoostPocket/Models/DataModelInfo.swift
@@ -26,8 +26,24 @@ struct CountryInfo {
 
 struct TravelInfo {
     private(set) var countryName: String
+    private(set) var id: UUID
+    private(set) var title: String
+    private(set) var memo: String
+    private(set) var startDate: Date
+    private(set) var endDate: Date
+    private(set) var coverImage: Data
+    private(set) var budget: Double
+    private(set) var exchangeRate: Double
     
-    init(countryName: String) {
+    init(countryName: String, id: UUID, title: String, memo: String, startDate: Date, endDate: Date, coverImage: Data, budget: Double, exchangeRate: Double) {
         self.countryName = countryName
+        self.id = id
+        self.title = title
+        self.memo = memo
+        self.startDate = startDate
+        self.endDate = endDate
+        self.coverImage = coverImage.getCoverImage() ?? Data()
+        self.budget = budget
+        self.exchangeRate = exchangeRate
     }
 }

--- a/BoostPocket/BoostPocket/Models/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/Models/PersistenceManager.swift
@@ -118,7 +118,6 @@ class PersistenceManager: PersistenceManagable {
     
     // MARK: - Core Data Fetching support
     
-    // TODO: - 테스트코드 작성하기
     func fetchAll<T: NSManagedObject>(request: NSFetchRequest<T>) -> [T] {
         if T.self == Country.self {
             let nameSort = NSSortDescriptor(key: "name", ascending: true)
@@ -136,7 +135,7 @@ class PersistenceManager: PersistenceManagable {
         }
     }
     
-    // TODO: - Seg fault 에러 알아보기
+    // TODO: - 테스트코드 작성하기
     func fetch(_ request: NSFetchRequest<NSFetchRequestResult>) -> [Any]? {
         do {
             let fetchResult = try self.context.fetch(request)

--- a/BoostPocket/BoostPocket/Models/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/Models/PersistenceManager.swift
@@ -135,7 +135,6 @@ class PersistenceManager: PersistenceManagable {
         }
     }
     
-    // TODO: - 테스트코드 작성하기
     func fetch(_ request: NSFetchRequest<NSFetchRequestResult>) -> [Any]? {
         do {
             let fetchResult = try self.context.fetch(request)

--- a/BoostPocket/BoostPocket/TravelListScene/TravelProvider.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelProvider.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import CoreData
 
 protocol TravelProvidable: AnyObject {
     var travels: [Travel] { get }
@@ -25,7 +24,7 @@ class TravelProvider: TravelProvidable {
     }
     
     func createTravel(countryName: String) -> Travel? {
-        let newTravelInfo = TravelInfo(countryName: countryName)
+        let newTravelInfo = TravelInfo(countryName: countryName, id: UUID(), title: countryName, memo: "", startDate: Date(), endDate: Date(), coverImage: Data(), budget: Double(), exchangeRate: Double())
         
         guard let createdObject = persistenceManager?.createObject(newObjectInfo: newTravelInfo),
             let createdTravel = createdObject as? Travel

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -16,16 +16,22 @@ class PersistenceManagerTests: XCTestCase {
     var countryInfo: CountryInfo!
     var travelInfo: TravelInfo!
     
+    let id = UUID()
+    let memo = ""
+    let startDate = Date()
+    let endDate = Date()
+    let coverImage = Data()
+    let budget = Double()
+    let exchangeRate = 1.5
     let countryName = "test name"
     let lastUpdated = Date()
     let flagImage = Data()
-    let exchangeRate = 1.5
     let currencyCode = "test code"
     
     override func setUpWithError() throws {
         persistenceManagerStub = PersistenceManagerStub()
         countryInfo = CountryInfo(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode)
-        travelInfo = TravelInfo(countryName: countryName)
+        travelInfo = TravelInfo(countryName: countryName, id: id, title: countryName, memo: memo, startDate: startDate, endDate: endDate, coverImage: coverImage, budget: budget, exchangeRate: exchangeRate)
     }
     
     override func tearDownWithError() throws {
@@ -73,6 +79,23 @@ class PersistenceManagerTests: XCTestCase {
         let fetchedCountry = persistenceManagerStub.fetch(fetchRequest) as? [Country]
         XCTAssertNotNil(fetchedCountry)
         XCTAssertEqual(fetchedCountry?.first, createdCountry)
+    }
+    
+    func test_persistenceManager_updateObject() {
+        let createdCountry = persistenceManagerStub.createObject(newObjectInfo: countryInfo) as? Country
+        let createdTravel = persistenceManagerStub.createObject(newObjectInfo: travelInfo) as? Travel
+        dump(createdTravel)
+        
+        XCTAssertNotNil(createdCountry)
+        XCTAssertNotNil(createdTravel)
+        
+        travelInfo = TravelInfo(countryName: countryName, id: id, title: countryName, memo: "updated memo", startDate: startDate, endDate: endDate, coverImage: coverImage, budget: budget, exchangeRate: exchangeRate)
+        
+        let updatedTravel = persistenceManagerStub.updateObject(updatedObjectInfo: travelInfo) as? Travel
+        dump(updatedTravel)
+        
+        XCTAssertNotNil(updatedTravel)
+        XCTAssertEqual(updatedTravel?.memo, "updated memo")
     }
     
     func test_persistenceManager_delete() {

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -71,6 +71,18 @@ class PersistenceManagerTests: XCTestCase {
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()).first, createdTravel)
     }
     
+    func test_persistenceManager_fetch() {
+        let createdCountry = persistenceManagerStub.createObject(newObjectInfo: countryInfo) as? Country
+        XCTAssertNotNil(createdCountry)
+        
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Country.entityName)
+        fetchRequest.predicate = NSPredicate(format: "name == %@", countryInfo.name)
+        
+        let fetchedCountry = persistenceManagerStub.fetch(fetchRequest) as? [Country]
+        XCTAssertNotNil(fetchedCountry)
+        XCTAssertEqual(fetchedCountry?.first, createdCountry)
+    }
+    
     func test_persistenceManager_delete() {
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()), [])
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Country.fetchRequest()), [])

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -35,21 +35,17 @@ class PersistenceManagerTests: XCTestCase {
     }
     
     func test_persistenceManager_createObject() {
-        let createdCountryObject = persistenceManagerStub.createObject(newObjectInfo: countryInfo)
-        let createdCountry = createdCountryObject as? Country
-        let fetchedCounties = persistenceManagerStub.fetchAll(request: Country.fetchRequest())
-        
-        XCTAssertNotNil(createdCountryObject)
+        let createdCountry = persistenceManagerStub.createObject(newObjectInfo: countryInfo) as? Country
         XCTAssertNotNil(createdCountry)
+        
+        let fetchedCounties = persistenceManagerStub.fetchAll(request: Country.fetchRequest())
         XCTAssertNotEqual(fetchedCounties, [])
         XCTAssertEqual(fetchedCounties.first, createdCountry)
         
-        let createdTravelObject = persistenceManagerStub.createObject(newObjectInfo: travelInfo)
-        let createdTravel = createdTravelObject as? Travel
-        let fetchedTravels = persistenceManagerStub.fetchAll(request: Travel.fetchRequest())
-        
-        XCTAssertNotNil(createdTravelObject)
+        let createdTravel = persistenceManagerStub.createObject(newObjectInfo: travelInfo) as? Travel
         XCTAssertNotNil(createdTravel)
+        
+        let fetchedTravels = persistenceManagerStub.fetchAll(request: Travel.fetchRequest())
         XCTAssertNotEqual(fetchedTravels, [])
         XCTAssertEqual(fetchedTravels.first, createdTravel)
     }
@@ -57,14 +53,10 @@ class PersistenceManagerTests: XCTestCase {
     func test_persistenceManager_fetchAll() {
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()), [])
         
-        let createdCountryObject = persistenceManagerStub.createObject(newObjectInfo: countryInfo)
-        let createdCountry = createdCountryObject as? Country
-        XCTAssertNotNil(createdCountryObject)
+        let createdCountry = persistenceManagerStub.createObject(newObjectInfo: countryInfo) as? Country
         XCTAssertNotNil(createdCountry)
         
-        let createdTravelObject = persistenceManagerStub.createObject(newObjectInfo: travelInfo)
-        let createdTravel = createdTravelObject as? Travel
-        XCTAssertNotNil(createdTravelObject)
+        let createdTravel = persistenceManagerStub.createObject(newObjectInfo: travelInfo) as? Travel
         XCTAssertNotNil(createdTravel)
         
         XCTAssertNotEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()), [])
@@ -87,14 +79,10 @@ class PersistenceManagerTests: XCTestCase {
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()), [])
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Country.fetchRequest()), [])
         
-        let createdCountryObject = persistenceManagerStub.createObject(newObjectInfo: countryInfo)
-        let createdCountry = createdCountryObject as? Country
-        let createdTravelObject = persistenceManagerStub.createObject(newObjectInfo: travelInfo)
-        let createdTravel = createdTravelObject as? Travel
+        let createdCountry = persistenceManagerStub.createObject(newObjectInfo: countryInfo) as? Country
+        let createdTravel = persistenceManagerStub.createObject(newObjectInfo: travelInfo) as? Travel
         
-        XCTAssertNotNil(createdCountryObject)
         XCTAssertNotNil(createdCountry)
-        XCTAssertNotNil(createdTravelObject)
         XCTAssertNotNil(createdTravel)
         
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Country.fetchRequest()).first, createdCountry)
@@ -110,14 +98,12 @@ class PersistenceManagerTests: XCTestCase {
     }
     
     func test_persistenceManager_count() {
-        let createdCountryObject = persistenceManagerStub.createObject(newObjectInfo: countryInfo)
-        XCTAssertNotNil(createdCountryObject)
+        XCTAssertNotNil(persistenceManagerStub.createObject(newObjectInfo: countryInfo) as? Country)
         XCTAssertEqual(persistenceManagerStub.count(request: Travel.fetchRequest()), 0)
         
         XCTAssertNotNil(persistenceManagerStub.createObject(newObjectInfo: travelInfo))
         XCTAssertNotNil(persistenceManagerStub.createObject(newObjectInfo: travelInfo))
         XCTAssertNotNil(persistenceManagerStub.createObject(newObjectInfo: travelInfo))
-        
         XCTAssertNotNil(persistenceManagerStub.count(request: Travel.fetchRequest()))
         XCTAssertEqual(persistenceManagerStub.count(request: Travel.fetchRequest()), 3)
     }

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -11,7 +11,7 @@ import CoreData
 @testable import BoostPocket
 
 class PersistenceManagerTests: XCTestCase {
-
+    
     var persistenceManagerStub: PersistenceManagable!
     var countryInfo: CountryInfo!
     var travelInfo: TravelInfo!
@@ -27,13 +27,13 @@ class PersistenceManagerTests: XCTestCase {
         countryInfo = CountryInfo(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode)
         travelInfo = TravelInfo(countryName: countryName)
     }
-
+    
     override func tearDownWithError() throws {
         persistenceManagerStub = nil
         countryInfo = nil
         travelInfo = nil
     }
-
+    
     func test_persistenceManager_createObject() {
         let createdCountryObject = persistenceManagerStub.createObject(newObjectInfo: countryInfo)
         let createdCountry = createdCountryObject as? Country
@@ -54,18 +54,22 @@ class PersistenceManagerTests: XCTestCase {
         XCTAssertEqual(fetchedTravels.first, createdTravel)
     }
     
-/*
-    func test_persistenceManager_fetch() {
-        let createdCountry = persistenceManagerStub.createObject(newObjectInfo: countryInfo)
+    func test_persistenceManager_fetchAll() {
+        XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()), [])
         
-        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Country.entityName)
-        fetchRequest.predicate = NSPredicate(format: "name == %@", countryName)
+        let createdCountryObject = persistenceManagerStub.createObject(newObjectInfo: countryInfo)
+        let createdCountry = createdCountryObject as? Country
+        XCTAssertNotNil(createdCountryObject)
+        XCTAssertNotNil(createdCountry)
         
-        let fetchResult = persistenceManagerStub.fetch(fetchRequest)
-        XCTAssertNotNil(fetchResult)
-        XCTAssertEqual(fetchResult?.first, createdCountry)
+        let createdTravelObject = persistenceManagerStub.createObject(newObjectInfo: travelInfo)
+        let createdTravel = createdTravelObject as? Travel
+        XCTAssertNotNil(createdTravelObject)
+        XCTAssertNotNil(createdTravel)
+        
+        XCTAssertNotEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()), [])
+        XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()).first, createdTravel)
     }
-*/
     
     func test_persistenceManager_delete() {
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()), [])
@@ -80,7 +84,7 @@ class PersistenceManagerTests: XCTestCase {
         XCTAssertNotNil(createdCountry)
         XCTAssertNotNil(createdTravelObject)
         XCTAssertNotNil(createdTravel)
-                
+        
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Country.fetchRequest()).first, createdCountry)
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()).first, createdTravel)
         


### PR DESCRIPTION
### Issue Number
Close #47 

### 변경사항
- PersistenceManager에 UpdateObject 함수 구현
- id 값으로 CoreData의 Travel을 fetch 한 후, NSManagedObject 클래스 내부 정보를 setValue를 통해 새로운 updated value들로 재설정하도록 구현
- 그 후, CoreData에 save가 정상적으로 됐다면 다시 fetch 해서 Travel을 return
- TravelInfo 객체에 countryName 뿐 아니라 Travel의 모든 정보를 갖도록 (country 제외) 요소를 추가함

### 새로운 기능
PersistenceManager에서 Travel을 update 할 수 있다.

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
