### PR TITLE
여행 업데이트 기능 추가

### DIFF
--- a/BoostPocket/BoostPocket/CountryListScene/CountryProvider.swift
+++ b/BoostPocket/BoostPocket/CountryListScene/CountryProvider.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol CountryProvidable: AnyObject {
     var countries: [Country] { get }
     func fetchCountries() -> [Country]
-    func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String) -> Country?
+    @discardableResult func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String) -> Country?
 }
 
 class CountryProvider: CountryProvidable {
@@ -32,6 +32,7 @@ class CountryProvider: CountryProvidable {
         return countries
     }
     
+    @discardableResult
     func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String) -> Country? {
         let newCountryInfo = CountryInfo(name: name,
                                          lastUpdated: lastUpdated,

--- a/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
@@ -22,7 +22,15 @@ protocol TravelItemPresentable {
     var currencyCode: String? { get }
 }
 
-struct TravelItemViewModel: TravelItemPresentable, Equatable, Hashable {
+class TravelItemViewModel: TravelItemPresentable, Equatable, Hashable {
+    static func == (lhs: TravelItemViewModel, rhs: TravelItemViewModel) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    
     var id: UUID?
     var title: String?
     var memo: String?

--- a/BoostPocket/BoostPocket/TravelListScene/TravelProvider.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelProvider.swift
@@ -13,6 +13,7 @@ protocol TravelProvidable: AnyObject {
     func createTravel(countryName: String) -> Travel?
     func fetchTravels() -> [Travel]
     func deleteTravel(id: UUID) -> Bool
+    func updateTravel(updatedTravelInfo: TravelInfo) -> Travel?
 }
 
 class TravelProvider: TravelProvidable {
@@ -39,6 +40,16 @@ class TravelProvider: TravelProvidable {
         travels = persistenceManager.fetchAll(request: Travel.fetchRequest())
         
         return travels
+    }
+    
+    func updateTravel(updatedTravelInfo: TravelInfo) -> Travel? {
+        guard let persistenceManager = persistenceManager,
+            let updatedTravel = persistenceManager.updateObject(updatedObjectInfo: updatedTravelInfo) as? Travel,
+            let indexToUpdate = travels.indices.filter({ travels[$0].id == updatedTravel.id }).first
+            else { return nil }
+        
+        self.travels[indexToUpdate] = updatedTravel
+        return updatedTravel
     }
     
     func deleteTravel(id: UUID) -> Bool {

--- a/BoostPocket/BoostPocketTests/TravelTests/TravelProviderTests.swift
+++ b/BoostPocket/BoostPocketTests/TravelTests/TravelProviderTests.swift
@@ -14,28 +14,31 @@ class TravelProviderTests: XCTestCase {
     var persistenceManagerStub: PersistenceManagable!
     var countryProvider: CountryProvidable!
     var travelProvider: TravelProvidable!
+    var countryInfo: CountryInfo!
     var country: Country!
-    
+
     let countryName = "대한민국"
     let lastUpdated = Date()
     let flagImage = Data()
     let exchangeRate = 1.5
     let currencyCode = "test code"
-
+    
     override func setUpWithError() throws {
         persistenceManagerStub = PersistenceManagerStub()
         countryProvider = CountryProvider(persistenceManager: persistenceManagerStub)
         travelProvider = TravelProvider(persistenceManager: persistenceManagerStub)
         
         country = countryProvider.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode)
+        countryInfo = CountryInfo(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode)
     }
-
+    
     override func tearDownWithError() throws {
         persistenceManagerStub = nil
         countryProvider = nil
         travelProvider = nil
+        countryInfo = nil
     }
-
+    
     func test_travelProvider_createTravel() {
         let createdTravel = travelProvider.createTravel(countryName: countryName)
         
@@ -55,6 +58,19 @@ class TravelProviderTests: XCTestCase {
         XCTAssertNotNil(fetchedTravel)
         XCTAssertEqual(fetchedTravel?.title, countryName)
         XCTAssertEqual(fetchedTravel?.exchangeRate, exchangeRate)
+    }
+    
+    func test_travelPrpvider_updateTravel() {
+        XCTAssertNotNil(persistenceManagerStub.createObject(newObjectInfo: countryInfo) as? Country)
+        
+        let createdTravel = travelProvider.createTravel(countryName: countryName)
+        XCTAssertNotNil(createdTravel)
+         
+        let travelInfo = TravelInfo(countryName: countryName, id: (createdTravel?.id)!, title: "updated title", memo: (createdTravel?.memo)!, startDate: (createdTravel?.startDate)!, endDate: (createdTravel?.endDate)!, coverImage: (createdTravel?.coverImage)!, budget: createdTravel!.budget, exchangeRate: createdTravel!.exchangeRate)
+        
+        XCTAssertNotNil(travelProvider.updateTravel(updatedTravelInfo: travelInfo))
+        XCTAssertEqual(travelProvider.fetchTravels().first, createdTravel)
+        XCTAssertEqual(travelProvider.fetchTravels().first?.title, "updated title")
     }
     
     func test_travelProvider_deleteTravel() {

--- a/BoostPocket/BoostPocketTests/TravelTests/TravelViewModelTests.swift
+++ b/BoostPocket/BoostPocketTests/TravelTests/TravelViewModelTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class TravelViewModelTests: XCTestCase {
     
     var travelListViewModel: TravelListPresentable!
-    var persistenceManager: PersistenceManagable!
+    var persistenceManagerStub: PersistenceManagable!
     var countryProvider: CountryProvidable!
     var travelProvider: TravelProvidable!
     var country: Country!
@@ -25,13 +25,17 @@ class TravelViewModelTests: XCTestCase {
     let coverImage = Data()
     let startDate = Date()
     let endDate = Date()
+    
     let countryName = "대한민국"
+    let lastUpdated = Date()
+    let flagImage = Data()
+    let currencyCode = "test code"
     
     override func setUpWithError() throws {
-        persistenceManager = PersistenceManagerStub()
-        countryProvider = CountryProvider(persistenceManager: persistenceManager)
+        persistenceManagerStub = PersistenceManagerStub()
+        countryProvider = CountryProvider(persistenceManager: persistenceManagerStub)
         country = countryProvider.createCountry(name: countryName, lastUpdated: Date(), flagImage: Data(), exchangeRate: 3.29, currencyCode: "KRW")
-        travelProvider = TravelProvider(persistenceManager: persistenceManager)
+        travelProvider = TravelProvider(persistenceManager: persistenceManagerStub)
         travelListViewModel = TravelListViewModel(countryProvider: countryProvider, travelProvider: travelProvider)
     }
     
@@ -40,7 +44,7 @@ class TravelViewModelTests: XCTestCase {
         travelProvider = nil
         country = nil
         countryProvider = nil
-        persistenceManager = nil
+        persistenceManagerStub = nil
     }
     
     func test_travelItemViewModel_createInstance() throws {
@@ -122,5 +126,13 @@ class TravelViewModelTests: XCTestCase {
         XCTAssertNotNil(createdTravel)
         XCTAssertNotNil(travelId)
         XCTAssertTrue(travelListViewModel.deleteTravel(id: travelId ?? UUID()))
+    }
+    
+    func test_travelListViewModel_updateTravel() {
+        XCTAssertNotNil(countryProvider.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode))
+        let createdTravel = travelListViewModel.createTravel(countryName: countryName)
+        XCTAssertNotNil(createdTravel)
+        
+        XCTAssertTrue(travelListViewModel.updateTravel(countryName: countryName, id: (createdTravel?.id)!, title: title, memo: "updated memo", startDate: startDate, endDate: endDate, coverImage: coverImage, budget: budget, exchangeRate: exchangeRate))
     }
 }


### PR DESCRIPTION
### Issue Number
Close #83 

### 변경사항
TravelProvider, TravelListViewModel에 Update 기능 구현 및 테스트코드 작성

### 새로운 기능
TravelListViewModel, TravelProvider를 통해 여행정보를 업데이트 할 수 있다.

TODO
TravelItemViewModel을 Class로 변경함으로써 여행프로필/지출목록/리포트 등 단일 여행 객체를 다루는 ViewController가 소유한 TravelItemViewModel 변수가 TravelListViewModel이 가리키는 실체화된 여행 객체들을 올바르게 참조하는지 확인해야한다. 

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
