### PR TITLE
여행 타이틀, 메모 수정 시 키보드가 뷰를 가리지 않도록 구현

### DIFF
--- a/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
@@ -31,36 +31,10 @@ class MemoEditViewController: UIViewController {
         unregisterForKeyboardNotifications()
     }
     
-    func registerForKeyboardNotifications() {
-        NotificationCenter.default.addObserver(self, selector:#selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector:#selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    func unregisterForKeyboardNotifications() {
-        NotificationCenter.default.removeObserver(self, name:UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name:UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         dismiss(animated: true) { [weak self] in
             self?.saveButtonHandler?(self?.memoTextView.text ?? "")
         }
-    }
-    
-    @objc func keyboardWillShow(note: NSNotification) {
-        if let keyboardSize = (note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            UIView.animate(withDuration: 0.3, animations: {
-                self.memoView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height / 3)
-            })
-        }
-    }
-    
-    @objc func keyboardWillHide(note: NSNotification) {
-        UIView.animate(withDuration: 0.3, animations: {
-            self.memoView.transform = .identity
-        })
-        
     }
 }
 
@@ -84,4 +58,30 @@ extension MemoEditViewController {
         viewController.present(vc, animated: true, completion: nil)
     }
     
+}
+
+extension MemoEditViewController {
+    func registerForKeyboardNotifications() {
+        NotificationCenter.default.addObserver(self, selector:#selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector:#selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    func unregisterForKeyboardNotifications() {
+        NotificationCenter.default.removeObserver(self, name:UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name:UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(note: NSNotification) {
+        if let keyboardSize = (note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.3, animations: {
+                self.memoView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height / 3)
+            })
+        }
+    }
+    
+    @objc func keyboardWillHide(note: NSNotification) {
+        UIView.animate(withDuration: 0.3, animations: {
+            self.memoView.transform = .identity
+        })
+    }
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
@@ -13,6 +13,8 @@ class MemoEditViewController: UIViewController {
     
     var saveButtonHandler: ((String) -> Void)?
     private var previousMemo: String?
+    
+    @IBOutlet weak var memoView: UIView!
     @IBOutlet weak var memoTextView: UITextView!
     
     override func viewDidLoad() {
@@ -20,10 +22,45 @@ class MemoEditViewController: UIViewController {
         self.memoTextView.text = previousMemo
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        registerForKeyboardNotifications()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        unregisterForKeyboardNotifications()
+    }
+    
+    func registerForKeyboardNotifications() {
+        NotificationCenter.default.addObserver(self, selector:#selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector:#selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    func unregisterForKeyboardNotifications() {
+        NotificationCenter.default.removeObserver(self, name:UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name:UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         dismiss(animated: true) { [weak self] in
             self?.saveButtonHandler?(self?.memoTextView.text ?? "")
         }
+    }
+    
+    @objc func keyboardWillShow(note: NSNotification) {
+        if let keyboardSize = (note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.3, animations: {
+                self.memoView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height / 3)
+            })
+        }
+    }
+    
+    @objc func keyboardWillHide(note: NSNotification) {
+        UIView.animate(withDuration: 0.3, animations: {
+            self.memoView.transform = .identity
+        })
+        
     }
 }
 
@@ -34,11 +71,11 @@ extension MemoEditViewController {
     static func present(at viewController: UIViewController,
                         previousMemo: String,
                         onDismiss: ((String) -> Void)?) {
-                
+        
         let storyBoard = UIStoryboard(name: storyboardName, bundle: Bundle.main)
         
         guard let vc = storyBoard.instantiateViewController(withIdentifier: MemoEditViewController.identifier) as? MemoEditViewController else { return }
-
+        
         vc.previousMemo = previousMemo
         vc.saveButtonHandler = onDismiss
         

--- a/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
@@ -31,6 +31,10 @@ class MemoEditViewController: UIViewController {
         unregisterForKeyboardNotifications()
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+    
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         dismiss(animated: true) { [weak self] in
             self?.saveButtonHandler?(self?.memoTextView.text ?? "")

--- a/BoostPocket/BoostPocket/TravelDetailScene/TitleEditViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TitleEditViewController.swift
@@ -12,6 +12,7 @@ class TitleEditViewController: UIViewController {
 
     var saveButtonHandler: ((String) -> Void)?
     
+    @IBOutlet weak var titleView: UIView!
     @IBOutlet weak var titleTextField: UITextField!
     
     override func viewDidLoad() {
@@ -20,10 +21,45 @@ class TitleEditViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        registerForKeyboardNotifications()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        unregisterForKeyboardNotifications()
+    }
+    
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         dismiss(animated: true) { [weak self] in
             self?.saveButtonHandler?(self?.titleTextField.text ?? "")
         }
     }
+}
 
+extension TitleEditViewController {
+    func registerForKeyboardNotifications() {
+        NotificationCenter.default.addObserver(self, selector:#selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector:#selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    func unregisterForKeyboardNotifications() {
+        NotificationCenter.default.removeObserver(self, name:UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name:UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(note: NSNotification) {
+        if let keyboardSize = (note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.3, animations: {
+                self.titleView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height / 3)
+            })
+        }
+    }
+    
+    @objc func keyboardWillHide(note: NSNotification) {
+        UIView.animate(withDuration: 0.3, animations: {
+            self.titleView.transform = .identity
+        })
+        
+    }
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/TitleEditViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TitleEditViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class TitleEditViewController: UIViewController {
-
+    
     var saveButtonHandler: ((String) -> Void)?
     
     @IBOutlet weak var titleView: UIView!
@@ -17,7 +17,7 @@ class TitleEditViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         // Do any additional setup after loading the view.
     }
     
@@ -28,6 +28,10 @@ class TitleEditViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         unregisterForKeyboardNotifications()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
     }
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
@@ -583,6 +583,7 @@
                     </view>
                     <connections>
                         <outlet property="titleTextField" destination="Xft-Lx-5eQ" id="NDF-qG-jZ7"/>
+                        <outlet property="titleView" destination="h3p-Pl-e1l" id="VeN-Lf-3CB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="arK-Sd-H2R" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -23,12 +25,12 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="gwU-vf-3l1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="nA7-O4-NF8" firstAttribute="centerY" secondItem="oSf-dj-s8a" secondAttribute="centerY" id="lCR-yy-TRh"/>
                             <constraint firstItem="nA7-O4-NF8" firstAttribute="centerX" secondItem="oSf-dj-s8a" secondAttribute="centerX" id="rOk-kI-ODB"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="gwU-vf-3l1"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="지출목록" image="list.bullet" catalog="system" id="wRC-jA-Szt"/>
                 </viewController>
@@ -51,12 +53,12 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="dz2-Wq-4eW"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="FNY-WL-G6t" firstAttribute="centerY" secondItem="sa6-cu-tQi" secondAttribute="centerY" id="5kr-D5-Qhh"/>
                             <constraint firstItem="FNY-WL-G6t" firstAttribute="centerX" secondItem="sa6-cu-tQi" secondAttribute="centerX" id="zvg-7h-b5Z"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="dz2-Wq-4eW"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="리포트" image="chart.pie.fill" catalog="system" id="hU1-KU-wkB"/>
                 </viewController>
@@ -83,22 +85,22 @@
                                             <subviews>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ngs-Bg-0Xj">
                                                     <rect key="frame" x="10" y="20" width="354" height="268"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                                    <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 </textView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="lvB-TX-H2s">
                                                     <rect key="frame" x="0.0" y="288" width="374" height="70"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-8R-MDG">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-8R-MDG">
                                                             <rect key="frame" x="0.0" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <state key="normal" title="취소">
                                                                 <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             </state>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Weu-7S-Dg6">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Weu-7S-Dg6">
                                                             <rect key="frame" x="187" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <state key="normal" title="완료">
@@ -114,7 +116,7 @@
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstItem="Ngs-Bg-0Xj" firstAttribute="leading" secondItem="cfT-us-jdV" secondAttribute="leading" constant="10" id="HOk-Hq-3mB"/>
                                                 <constraint firstItem="Ngs-Bg-0Xj" firstAttribute="top" secondItem="cfT-us-jdV" secondAttribute="top" constant="20" id="IbE-4r-ZTp"/>
@@ -149,10 +151,10 @@
                             <constraint firstAttribute="trailing" secondItem="2y1-T4-y8R" secondAttribute="trailing" id="kWs-Fn-Nle"/>
                             <constraint firstItem="cfT-us-jdV" firstAttribute="height" secondItem="nnu-cz-oT4" secondAttribute="height" multiplier="0.4" id="yCN-Ju-RMh"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="iUf-qp-RhL"/>
                     </view>
                     <connections>
                         <outlet property="memoTextView" destination="Ngs-Bg-0Xj" id="MC5-YO-gnw"/>
+                        <outlet property="memoView" destination="cfT-us-jdV" id="E9e-bj-Wh1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xkd-Ve-38h" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -333,13 +335,13 @@
                                                                                 <color key="backgroundColor" name="mainColor"/>
                                                                             </view>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 %" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XiF-QM-NZR">
-                                                                                <rect key="frame" x="10" y="6" width="26" height="18"/>
+                                                                                <rect key="frame" x="10" y="6" width="27" height="18"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                         </subviews>
-                                                                        <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                         <constraints>
                                                                             <constraint firstItem="Cgj-k5-VFd" firstAttribute="top" secondItem="qvF-Ok-csh" secondAttribute="top" id="Flf-h1-W0M"/>
                                                                             <constraint firstItem="XiF-QM-NZR" firstAttribute="centerY" secondItem="qvF-Ok-csh" secondAttribute="centerY" id="YBr-5F-AuR"/>
@@ -354,13 +356,13 @@
                                                                         <rect key="frame" x="0.0" y="104" width="374" height="16"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="₩ 25,000 사용" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V5d-JZ-sid">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="185" height="16"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="185.5" height="16"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KRW 15,000 남음/₩ 23,000 초과" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rmn-Fr-kXg">
-                                                                                <rect key="frame" x="185" y="0.0" width="189" height="16"/>
+                                                                                <rect key="frame" x="185.5" y="0.0" width="188.5" height="16"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <nil key="highlightedColor"/>
@@ -395,7 +397,7 @@
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eHl-w2-LWW" userLabel="Button View">
                                                                 <rect key="frame" x="0.0" y="934" width="374" height="37.5"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIM-lz-bbD">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIM-lz-bbD">
                                                                         <rect key="frame" x="131" y="0.0" width="112" height="37.5"/>
                                                                         <color key="backgroundColor" name="DeleteButtonColor"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
@@ -413,7 +415,7 @@
                                                                         </connections>
                                                                     </button>
                                                                 </subviews>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <constraints>
                                                                     <constraint firstItem="eIM-lz-bbD" firstAttribute="top" secondItem="eHl-w2-LWW" secondAttribute="top" id="GmL-Jd-PP6"/>
                                                                     <constraint firstAttribute="width" secondItem="eHl-w2-LWW" secondAttribute="height" multiplier="10:1" id="MIb-du-ecy"/>
@@ -430,7 +432,7 @@
                                                         </constraints>
                                                     </stackView>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="bottom" secondItem="Ma0-RF-0Rk" secondAttribute="bottom" constant="20" id="0mA-rw-gX3"/>
                                                     <constraint firstItem="Ma0-RF-0Rk" firstAttribute="leading" secondItem="6aw-iA-A5G" secondAttribute="leading" constant="20" id="6Zs-hF-1E0"/>
@@ -447,7 +449,7 @@
                                         </constraints>
                                     </scrollView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="ux4-FQ-XbC" firstAttribute="leading" secondItem="YI3-ni-eQX" secondAttribute="leading" id="4ab-jw-mb0"/>
                                     <constraint firstAttribute="trailing" secondItem="6aw-iA-A5G" secondAttribute="trailing" id="BRO-JO-oy2"/>
@@ -457,14 +459,14 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="GL9-dr-PWQ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="YI3-ni-eQX" firstAttribute="top" secondItem="GL9-dr-PWQ" secondAttribute="top" id="Z2W-2W-yeL"/>
                             <constraint firstItem="GL9-dr-PWQ" firstAttribute="trailing" secondItem="YI3-ni-eQX" secondAttribute="trailing" id="ZjF-4e-1c4"/>
                             <constraint firstItem="YI3-ni-eQX" firstAttribute="leading" secondItem="GL9-dr-PWQ" secondAttribute="leading" id="epO-JR-yDD"/>
                             <constraint firstItem="GL9-dr-PWQ" firstAttribute="bottom" secondItem="YI3-ni-eQX" secondAttribute="bottom" id="ysR-Y0-u4J"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="GL9-dr-PWQ"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="여행프로필" image="airplane" catalog="system" id="Ln5-3b-m3G"/>
                     <connections>
@@ -590,7 +592,7 @@
     </scenes>
     <resources>
         <image name="airplane" catalog="system" width="128" height="115"/>
-        <image name="chart.pie.fill" catalog="system" width="128" height="124"/>
+        <image name="chart.pie.fill" catalog="system" width="128" height="121"/>
         <image name="list.bullet" catalog="system" width="128" height="88"/>
         <namedColor name="DeleteButtonColor">
             <color red="0.98600000143051147" green="0.72399997711181641" blue="0.73100000619888306" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -601,5 +603,14 @@
         <namedColor name="mainColor">
             <color red="0.45899999141693115" green="0.75700002908706665" blue="0.9570000171661377" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelProfileViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelProfileViewController.swift
@@ -18,7 +18,6 @@ class TravelProfileViewController: UIViewController {
     var travelItemViewModel: TravelItemPresentable?
     weak var profileDelegate: TravelProfileDelegate?
     
-    @IBOutlet weak var travelTitleLabel: UILabel!
     @IBOutlet weak var travelMemoLabel: UILabel!
     @IBOutlet weak var travelTitleLabel: UILabel!
     


### PR DESCRIPTION
### Issue Number
Close #91 

### 새로운 기능
- Observer 등록을 통해 키보드 show, hide 감지
```swift
let keyboardSize = (note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
```
- 키보드 사이즈를 기준으로 뷰를 CGAffineTransform 적용
- 키보드가 내려오면 뷰를 identity를 통해 제자리로 이동시킴

![키보드](https://user-images.githubusercontent.com/65107199/100628859-04814f80-336c-11eb-91af-22f5363bda43.gif)

- 편집 모드에서 뷰 바깥쪽을 터치하면 editing이 종료되도록 구현
        - touchesBegan을 override하여 endEditing 설정

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
