### PR TITLE
여행 생성 시 환욜 요청 기능 구현

### DIFF
--- a/BoostPocket/BoostPocket/Extensions/Date+ConvertToString.swift
+++ b/BoostPocket/BoostPocket/Extensions/Date+ConvertToString.swift
@@ -22,3 +22,15 @@ extension Date {
         return formatter.string(from: self)
     }
 }
+
+extension String {
+    func convertToDate() -> Date {
+        let dateString :String = self
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
+
+        let date: Date = dateFormatter.date(from: dateString)!
+        return date
+    }
+}

--- a/BoostPocket/BoostPocket/Models/DataModelInfo.swift
+++ b/BoostPocket/BoostPocket/Models/DataModelInfo.swift
@@ -28,14 +28,14 @@ struct TravelInfo {
     private(set) var countryName: String
     private(set) var id: UUID
     private(set) var title: String
-    private(set) var memo: String
-    private(set) var startDate: Date
-    private(set) var endDate: Date
+    private(set) var memo: String?
+    private(set) var startDate: Date?
+    private(set) var endDate: Date?
     private(set) var coverImage: Data
     private(set) var budget: Double
     private(set) var exchangeRate: Double
     
-    init(countryName: String, id: UUID, title: String, memo: String, startDate: Date, endDate: Date, coverImage: Data, budget: Double, exchangeRate: Double) {
+    init(countryName: String, id: UUID, title: String, memo: String?, startDate: Date?, endDate: Date?, coverImage: Data, budget: Double, exchangeRate: Double) {
         self.countryName = countryName
         self.id = id
         self.title = title

--- a/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
@@ -16,7 +16,7 @@ protocol TravelListPresentable {
     @discardableResult func createTravel(countryName: String) -> TravelItemViewModel?
     func needFetchItems()
     func cellForItemAt(path: IndexPath) -> TravelItemViewModel?
-    func updateTravel(countryName: String, id: UUID, title: String, memo: String, startDate: Date, endDate: Date, coverImage: Data, budget: Double, exchangeRate: Double) -> Bool
+    func updateTravel(countryName: String, id: UUID, title: String, memo: String?, startDate: Date?, endDate: Date?, coverImage: Data, budget: Double, exchangeRate: Double) -> Bool
     func deleteTravel(id: UUID) -> Bool
     func numberOfItem() -> Int
 }
@@ -61,7 +61,7 @@ class TravelListViewModel: TravelListPresentable {
         return travels[path.row]
     }
     
-    func updateTravel(countryName: String, id: UUID, title: String, memo: String, startDate: Date, endDate: Date, coverImage: Data, budget: Double, exchangeRate: Double) -> Bool {
+    func updateTravel(countryName: String, id: UUID, title: String, memo: String?, startDate: Date?, endDate: Date?, coverImage: Data, budget: Double, exchangeRate: Double) -> Bool {
         let travelInfo = TravelInfo(countryName: countryName, id: id, title: title, memo: memo, startDate: startDate, endDate: endDate, coverImage: coverImage, budget: budget, exchangeRate: exchangeRate)
         
         guard let updatedTravel = travelProvider?.updateTravel(updatedTravelInfo: travelInfo),

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
@@ -215,21 +215,17 @@ extension TravelListViewController: TravelProfileDelegate {
         }
     }
     
-    func updateTravel(id: UUID? = nil, newTitle: String? = nil, newMemo: String?, newStartDate: Date? = nil, newEndDate: Date? = nil, newCoverImage: Data? = nil, newBudget: Double? = nil, newExchangeRate: Double? = nil) {
-        if let travelListViewModel = travelListViewModel,
-            let updatingId = id,
-            let updatingTravel = travelListViewModel.travels.filter({ $0.id == updatingId }).first,
-            let countryName = updatingTravel.countryName,
-            let title = updatingTravel.title,
-            let memo = updatingTravel.memo,
-            let startDate = updatingTravel.startDate,
-            let endDate = updatingTravel.endDate,
-            let coverImage = updatingTravel.coverImage,
-            
-            travelListViewModel.updateTravel(countryName: countryName, id: updatingId, title: newTitle ?? title, memo: newMemo ?? memo, startDate: newStartDate ?? startDate, endDate: newEndDate ?? endDate, coverImage: newCoverImage ?? coverImage, budget: newBudget ?? updatingTravel.budget, exchangeRate: newExchangeRate ?? updatingTravel.exchangeRate) {
-            print("여행 정보 업데이트 성공")
-        } else {
-            print("여행 정보 업데이트 실패")
+    func updateTravel(id: UUID? = nil, newTitle: String? = nil, newMemo: String? = nil, newStartDate: Date? = nil, newEndDate: Date? = nil, newCoverImage: Data? = nil, newBudget: Double? = nil, newExchangeRate: Double? = nil) {
+            if let travelListViewModel = travelListViewModel,
+                let updatingId = id,
+                let updatingTravel = travelListViewModel.travels.filter({ $0.id == updatingId }).first,
+                let countryName = updatingTravel.countryName,
+                let title = updatingTravel.title,
+                let coverImage = updatingTravel.coverImage,
+                travelListViewModel.updateTravel(countryName: countryName, id: updatingId, title: newTitle ?? title, memo: newMemo, startDate: newStartDate, endDate: newEndDate, coverImage: newCoverImage ?? coverImage, budget: newBudget ?? updatingTravel.budget, exchangeRate: newExchangeRate ?? updatingTravel.exchangeRate) {
+                print("여행 정보 업데이트 성공")
+            } else {
+                print("여행 정보 업데이트 실패")
+            }
         }
-    }
 }

--- a/BoostPocket/BoostPocketTests/CountryTests/CountryProviderTests.swift
+++ b/BoostPocket/BoostPocketTests/CountryTests/CountryProviderTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import NetworkManager
 @testable import BoostPocket
 
 class CountryProviderTests: XCTestCase {
@@ -21,7 +22,9 @@ class CountryProviderTests: XCTestCase {
     let currencyCode = "test code"
     
     override func setUpWithError() throws {
-        persistenceManagerStub = PersistenceManagerStub()
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+        let dataLoader = DataLoader(session: session)
+        persistenceManagerStub = PersistenceManagerStub(dataLoader: dataLoader)
         countryProviderStub = CountryProvider(persistenceManager: persistenceManagerStub)
     }
 

--- a/BoostPocket/BoostPocketTests/CountryTests/CountryViewModelTests.swift
+++ b/BoostPocket/BoostPocketTests/CountryTests/CountryViewModelTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import NetworkManager
 @testable import BoostPocket
 
 class CountryViewModelTests: XCTestCase {
@@ -22,7 +23,9 @@ class CountryViewModelTests: XCTestCase {
     let currencyCode = "test code"
     
     override func setUpWithError() throws {
-        persistenceManager = PersistenceManagerStub()
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+        let dataLoader = DataLoader(session: session)
+        persistenceManager = PersistenceManagerStub(dataLoader: dataLoader)
         countryProvider = CountryProvider(persistenceManager: persistenceManager)
         countryListViewModel = CountryListViewModel(countryProvider: countryProvider)
     }

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerStub.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerStub.swift
@@ -8,11 +8,12 @@
 
 import Foundation
 import CoreData
+import NetworkManager
 @testable import BoostPocket
 
 class PersistenceManagerStub: PersistenceManager {
-    override init() {
-        super.init()
+    override init(dataLoader: DataLoader) {
+        super.init(dataLoader: dataLoader)
         
         let persistentStoreDescription = NSPersistentStoreDescription()
         persistentStoreDescription.type = NSInMemoryStoreType

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -8,10 +8,10 @@
 
 import XCTest
 import CoreData
+import NetworkManager
 @testable import BoostPocket
 
 class PersistenceManagerTests: XCTestCase {
-    
     var persistenceManagerStub: PersistenceManagable!
     var countryInfo: CountryInfo!
     var travelInfo: TravelInfo!
@@ -29,7 +29,9 @@ class PersistenceManagerTests: XCTestCase {
     let currencyCode = "test code"
     
     override func setUpWithError() throws {
-        persistenceManagerStub = PersistenceManagerStub()
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+        let dataLoader = DataLoader(session: session)
+        persistenceManagerStub = PersistenceManagerStub(dataLoader: dataLoader)
         countryInfo = CountryInfo(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode)
         travelInfo = TravelInfo(countryName: countryName, id: id, title: countryName, memo: memo, startDate: startDate, endDate: endDate, coverImage: coverImage, budget: budget, exchangeRate: exchangeRate)
     }

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -56,6 +56,19 @@ class PersistenceManagerTests: XCTestCase {
         XCTAssertEqual(fetchedTravels.first, createdTravel)
     }
     
+    func test_persistenceManager_isExchangeRateOutdated() {
+        let dateString: String = "2020-11-30 10:20:00"
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
+        
+        let yeaterday: Date = dateFormatter.date(from: dateString)!
+        let today = Date()
+        
+        XCTAssertFalse(persistenceManagerStub.isExchangeRateOutdated(lastUpdated: today))
+        XCTAssertTrue(persistenceManagerStub.isExchangeRateOutdated(lastUpdated: yeaterday))
+    }
+    
     func test_persistenceManager_fetchAll() {
         XCTAssertEqual(persistenceManagerStub.fetchAll(request: Travel.fetchRequest()), [])
         

--- a/BoostPocket/BoostPocketTests/TravelTests/TravelProviderTests.swift
+++ b/BoostPocket/BoostPocketTests/TravelTests/TravelProviderTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import NetworkManager
 @testable import BoostPocket
 
 class TravelProviderTests: XCTestCase {
@@ -24,7 +25,9 @@ class TravelProviderTests: XCTestCase {
     let currencyCode = "test code"
     
     override func setUpWithError() throws {
-        persistenceManagerStub = PersistenceManagerStub()
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+        let dataLoader = DataLoader(session: session)
+        persistenceManagerStub = PersistenceManagerStub(dataLoader: dataLoader)
         countryProvider = CountryProvider(persistenceManager: persistenceManagerStub)
         travelProvider = TravelProvider(persistenceManager: persistenceManagerStub)
         

--- a/BoostPocket/BoostPocketTests/TravelTests/TravelViewModelTests.swift
+++ b/BoostPocket/BoostPocketTests/TravelTests/TravelViewModelTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import NetworkManager
 @testable import BoostPocket
 
 class TravelViewModelTests: XCTestCase {
@@ -32,7 +33,9 @@ class TravelViewModelTests: XCTestCase {
     let currencyCode = "test code"
     
     override func setUpWithError() throws {
-        persistenceManagerStub = PersistenceManagerStub()
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+        let dataLoader = DataLoader(session: session)
+        persistenceManagerStub = PersistenceManagerStub(dataLoader: dataLoader)
         countryProvider = CountryProvider(persistenceManager: persistenceManagerStub)
         country = countryProvider.createCountry(name: countryName, lastUpdated: Date(), flagImage: Data(), exchangeRate: 3.29, currencyCode: "KRW")
         travelProvider = TravelProvider(persistenceManager: persistenceManagerStub)


### PR DESCRIPTION
### Issue Number
Close #94 

### 변경사항
여행 생성 시 바로 생성하는 것이 아니라 lastUpdated의 outdated 여부를 판단 후, 오래됐다면 환율 API 요청하도록 수정

### 새로운 기능
여행 생성 시 가장 최근의 환율 정보로 유지할 수 있다.

TODO
네트워크 관련 테스트코드 작성 및 디버깅 
테스트코드에서 DataLoader Stub 생성

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
