### PR TITLE
setupCountries, filterCountries 함수 이동/수정/테스트코드 작성

### DIFF
--- a/BoostPocket/BoostPocket/Models/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/Models/PersistenceManager.swift
@@ -16,6 +16,7 @@ protocol PersistenceManagable: AnyObject {
     var persistentContainer: NSPersistentContainer { get }
     var context: NSManagedObjectContext { get }
     
+    func filterCountries(_ identifiers: [String], rates: [String : Double]) -> [String: String]
     func createObject<T>(newObjectInfo: T, completion: @escaping (DataModelProtocol?) -> Void)
     func fetchAll<T: NSManagedObject>(request: NSFetchRequest<T>) -> [T]
     func fetch(_ request: NSFetchRequest<NSFetchRequestResult>) -> [Any]?
@@ -74,7 +75,7 @@ class PersistenceManager: PersistenceManagable {
     private func setupCountries(with data: ExchangeRate) {
         let koreaLocale = NSLocale(localeIdentifier: "ko_KR")
         let identifiers = NSLocale.availableLocaleIdentifiers
-        let countryDictionary = filterCountries(identifiers, data: data)
+        let countryDictionary = filterCountries(identifiers, rates: data.rates)
         
         countryDictionary.forEach { (countryCode, identifier) in
             let locale = NSLocale(localeIdentifier: identifier)
@@ -93,15 +94,14 @@ class PersistenceManager: PersistenceManagable {
         }
     }
     
-    // TODO: - 테스트코드 작성하기
-    private func filterCountries(_ identifiers: [String], data: ExchangeRate) -> [String: String] {
+    func filterCountries(_ identifiers: [String], rates: [String: Double]) -> [String: String] {
         var filteredIdentifiers: [String: String] = [:]
         
         identifiers.forEach { identifier in
             let locale = NSLocale(localeIdentifier: identifier)
             if let currencyCode = locale.currencyCode,
                 let countryCode = locale.countryCode,
-                let _ = data.rates[currencyCode],
+                let _ = rates[currencyCode],
                 let _ = Flag(countryCode: countryCode)?.originalImage.pngData() {
                 filteredIdentifiers[countryCode] = identifier
             }

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -45,6 +45,14 @@ class PersistenceManagerTests: XCTestCase {
         travelInfo = nil
     }
     
+    func test_persistenceManager_filterCountries() {
+        let identifiers = ["ko_KR", "ja_JP"]
+        let rates = ["KRW": 1.0, "JPY": 0.0941570188]
+        let expected = ["KR": "ko_KR", "JP": "ja_JP"]
+        
+        XCTAssertEqual(expected, persistenceManagerStub.filterCountries(identifiers, rates: rates))
+    }
+    
     func test_persistenceManager_createObject() {
         let countryExpectation = XCTestExpectation(description: "Successfully Created Country")
         var createdCountry: Country?


### PR DESCRIPTION
### Issue Number
Close #109 

### 변경사항
SceneDelegate을 최대한 가볍게 유지하기 위해서 API요청 및 국가정보 저장하는 로직을 분리해봤습니다!
새벽코딩이라 비몽사몽하네여 ㅎ.. 코드리뷰 잘부탁드립니다 ㅠ 실수했을수도있어서!!

- SceneDeleagate에서 하던 앱 초기실행 시 국가정보저장 로직 persistenceManager로 이동
- 이에 따라 SceneDelegate에서 FlagKit import할 필요 X
- createCountriesWithAPIRequest 함수는 비동기처리하되 SceneDelegate에서 분리되었으므로 화면 구성하는 로직을 main queue에 넣어줄 필요가 없어짐
- filterCountries 함수: data 전체를 보내던 기존의 구조 -> rates만 따로 보내도록 함수 수정
- 테스트코드 작성

### 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
