### PR TITLE
Travel 관련 테스트코드 개선

### DIFF
--- a/BoostPocket/BoostPocket/SceneDelegate.swift
+++ b/BoostPocket/BoostPocket/SceneDelegate.swift
@@ -27,7 +27,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let countryProvider = CountryProvider(persistenceManager: persistenceManager)
         let travelProvider = TravelProvider(persistenceManager: persistenceManager)
 
-        persistenceManager.createCountriesWithAPIRequest()
+        persistenceManager.createCountriesWithAPIRequest { (result) in
+            if result { print("국가 생성 성공") }
+            else { print("국가 생성 실패") }
+        }
         
         let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
         guard let mainNavigationController = storyboard.instantiateViewController(identifier: "MainNavigationViewController") as? UINavigationController,

--- a/BoostPocket/BoostPocket/SceneDelegate.swift
+++ b/BoostPocket/BoostPocket/SceneDelegate.swift
@@ -28,8 +28,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let travelProvider = TravelProvider(persistenceManager: persistenceManager)
 
         persistenceManager.createCountriesWithAPIRequest { (result) in
-            if result { print("국가 생성 성공") }
-            else { print("국가 생성 실패") }
+            if result {
+                print("국가 생성 성공")
+            } else {
+                print("국가 생성 실패")
+            }
         }
         
         let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)


### PR DESCRIPTION
### Issue Number
Close #115 

### 변경사항
- country, countryProvider를 삭제하여 Travel 테스트에만 집중하도록 코드 간소화
- Travel 생성/수정/삭제에 필수적인 Country 생성 작업은 persistenceManager에서 하도록
  로직 변경
- 해당 로직이 비동기이므로 expectation 추가
- TravelViewModelTests : TravelProvider 테스트코드 개선과 내용은 동일함

### 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
