### PR TITLE
History 필터기능 구현 및 지출/수입 추가화면 간단한 UI 틀

### DIFF
--- a/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
+++ b/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		9572F9B3256B974C003049CB /* PersistenceManagerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9572F9B2256B974C003049CB /* PersistenceManagerStub.swift */; };
 		95747A67256FAF6B0065C419 /* TravelDetailTabbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95747A66256FAF6B0065C419 /* TravelDetailTabbarController.swift */; };
 		95747A69256FCEEA0065C419 /* Data+ImageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95747A68256FCEEA0065C419 /* Data+ImageData.swift */; };
+		9574ACD02578B4C10072C578 /* AddHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9574ACCE2578B4C10072C578 /* AddHistoryViewController.swift */; };
+		9574ACD12578B4C10072C578 /* AddHistoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9574ACCF2578B4C10072C578 /* AddHistoryViewController.xib */; };
 		9579CBB7256E46A900E74A61 /* DataModelInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9579CBB6256E46A900E74A61 /* DataModelInfo.swift */; };
 		9581C709256E34AC006ABA8E /* PersistenceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9581C708256E34AC006ABA8E /* PersistenceManagerTests.swift */; };
 		95A42E7A25664DBE0007810C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E7925664DBE0007810C /* AppDelegate.swift */; };
@@ -169,6 +171,8 @@
 		9572F9B2256B974C003049CB /* PersistenceManagerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManagerStub.swift; sourceTree = "<group>"; };
 		95747A66256FAF6B0065C419 /* TravelDetailTabbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelDetailTabbarController.swift; sourceTree = "<group>"; };
 		95747A68256FCEEA0065C419 /* Data+ImageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+ImageData.swift"; sourceTree = "<group>"; };
+		9574ACCE2578B4C10072C578 /* AddHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddHistoryViewController.swift; sourceTree = "<group>"; };
+		9574ACCF2578B4C10072C578 /* AddHistoryViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddHistoryViewController.xib; sourceTree = "<group>"; };
 		9579CBB6256E46A900E74A61 /* DataModelInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataModelInfo.swift; sourceTree = "<group>"; };
 		9581C708256E34AC006ABA8E /* PersistenceManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManagerTests.swift; sourceTree = "<group>"; };
 		95A42E7625664DBE0007810C /* BoostPocket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoostPocket.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -316,6 +320,8 @@
 				5C15AB432577C96E00244C6C /* HistoryListViewController.swift */,
 				5C15AB482577DED700244C6C /* HistoryHeaderCell.swift */,
 				5C15AB4D2577DEE900244C6C /* HistoryHeaderCell.xib */,
+				9574ACCE2578B4C10072C578 /* AddHistoryViewController.swift */,
+				9574ACCF2578B4C10072C578 /* AddHistoryViewController.xib */,
 			);
 			path = TravelDetailScene;
 			sourceTree = "<group>";
@@ -650,6 +656,7 @@
 				5C15AB4E2577DEE900244C6C /* HistoryHeaderCell.xib in Resources */,
 				5C15AB3F2577C32000244C6C /* HistoryCell.xib in Resources */,
 				5C3DAF3625665F0200178EA0 /* CountryCell.xib in Resources */,
+				9574ACD12578B4C10072C578 /* AddHistoryViewController.xib in Resources */,
 				95A42E8925664DC40007810C /* LaunchScreen.storyboard in Resources */,
 				5C797494256FD263007CB1ED /* TravelHeaderCell.xib in Resources */,
 				A9BF7A87256F420D00496CD8 /* TravelCell.xib in Resources */,
@@ -776,6 +783,7 @@
 				95A42E7E25664DBE0007810C /* TravelListViewController.swift in Sources */,
 				5C3DAF3E25666B4D00178EA0 /* TravelProfileViewController.swift in Sources */,
 				95747A67256FAF6B0065C419 /* TravelDetailTabbarController.swift in Sources */,
+				9574ACD02578B4C10072C578 /* AddHistoryViewController.swift in Sources */,
 				9579CBB7256E46A900E74A61 /* DataModelInfo.swift in Sources */,
 				5CD76EBB256C935E00BD6CE3 /* Country+CoreDataProperties.swift in Sources */,
 				5C3DAF2F2566576000178EA0 /* CountryListViewController.swift in Sources */,

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -11,9 +11,82 @@ import UIKit
 class AddHistoryViewController: UIViewController {
     static let identifier = "AddHistoryViewController"
     
+    var saveButtonHandler: ((HistoryItemViewModel) -> Void)?
+    weak var travelItemViewModel: HistoryListPresentable?
+    
+    @IBOutlet weak var historyTypeLabel: UILabel!
+    @IBOutlet weak var flagImageView: UIImageView!
+    @IBOutlet weak var currencyCodeLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureViews()
     }
+ 
+    private func configureViews() {
+        flagImageView.image = UIImage(data: travelItemViewModel?.flagImage ?? Data())
+        currencyCodeLabel.text = travelItemViewModel?.currencyCode
+    }
+    
+    @IBAction func cancelButtonTapped(_ sender: Any) {
+    }
+    
+    @IBAction func saveButtonTapped(_ sender: Any) {
+        // saveButtonHandler?()
+    }
+    
+}
 
+// MARK: - Calculator IBActions
 
+extension AddHistoryViewController {
+    
+    @IBAction func oneTapped(_ sender: Any) {
+    }
+    
+    @IBAction func twoTapped(_ sender: Any) {
+    }
+    
+    @IBAction func threeTapped(_ sender: Any) {
+    }
+    
+    @IBAction func fourTapped(_ sender: Any) {
+    }
+    
+    @IBAction func fiveTapped(_ sender: Any) {
+    }
+    
+    @IBAction func sixTapped(_ sender: Any) {
+    }
+    
+    @IBAction func sevenTapped(_ sender: Any) {
+    }
+    
+    @IBAction func eightTapped(_ sender: Any) {
+    }
+    
+    @IBAction func nineTapped(_ sender: Any) {
+    }
+    
+    @IBAction func zeroTapped(_ sender: Any) {
+    }
+    
+    @IBAction func dotTapped(_ sender: Any) {
+    }
+    
+    @IBAction func backTapped(_ sender: Any) {
+    }
+    
+    @IBAction func divisionTapped(_ sender: Any) {
+    }
+    
+    @IBAction func multiplyTapped(_ sender: Any) {
+    }
+    
+    @IBAction func additionTapped(_ sender: Any) {
+    }
+    
+    @IBAction func subtractionTapped(_ sender: Any) {
+    }
+    
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -1,0 +1,19 @@
+//
+//  AddHistoryViewController.swift
+//  BoostPocket
+//
+//  Created by sihyung you on 2020/12/03.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+import UIKit
+
+class AddHistoryViewController: UIViewController {
+    static let identifier = "AddHistoryViewController"
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+
+}

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.xib
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.xib
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddHistoryViewController" customModule="BoostPocket" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" restorationIdentifier="AddHistoryViewController" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" name="DeleteButtonColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="132" y="151"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="DeleteButtonColor">
+            <color red="0.98600000143051147" green="0.72399997711181641" blue="0.73100000619888306" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.xib
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.xib
@@ -10,6 +10,9 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddHistoryViewController" customModule="BoostPocket" customModuleProvider="target">
             <connections>
+                <outlet property="currencyCodeLabel" destination="qEf-JD-335" id="nB3-XZ-Ovi"/>
+                <outlet property="flagImageView" destination="3WX-Mq-2i1" id="udC-nC-cHA"/>
+                <outlet property="historyTypeLabel" destination="X8B-Q2-jmd" id="vNd-sq-bhB"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -17,12 +20,248 @@
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" restorationIdentifier="AddHistoryViewController" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" name="DeleteButtonColor"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fLx-PJ-SRJ">
+                    <rect key="frame" x="0.0" y="44" width="414" height="126.5"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지출/수입" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X8B-Q2-jmd">
+                            <rect key="frame" x="10" y="5" width="64.5" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3WX-Mq-2i1">
+                            <rect key="frame" x="10" y="40.5" width="83" height="55"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="3WX-Mq-2i1" secondAttribute="height" multiplier="3:2" id="bM2-HB-Vc6"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tkA-TC-4Rx">
+                            <rect key="frame" x="362" y="19.5" width="42" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aLb-EL-GfB">
+                            <rect key="frame" x="362" y="96" width="42" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qEf-JD-335">
+                            <rect key="frame" x="103" y="58" width="42" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="20" translatesAutoresizingMaskIntoConstraints="NO" id="4pe-9q-UpJ">
+                            <rect key="frame" x="327.5" y="50" width="76.5" height="36"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" name="DeleteButtonColor"/>
+                    <constraints>
+                        <constraint firstItem="X8B-Q2-jmd" firstAttribute="top" secondItem="fLx-PJ-SRJ" secondAttribute="top" constant="5" id="6aP-Qx-3qQ"/>
+                        <constraint firstAttribute="trailing" secondItem="4pe-9q-UpJ" secondAttribute="trailing" constant="10" id="7aV-K4-GeC"/>
+                        <constraint firstItem="aLb-EL-GfB" firstAttribute="trailing" secondItem="4pe-9q-UpJ" secondAttribute="trailing" id="PCG-bA-jRg"/>
+                        <constraint firstItem="3WX-Mq-2i1" firstAttribute="width" secondItem="fLx-PJ-SRJ" secondAttribute="width" multiplier="0.2" id="Pv5-BI-DGO"/>
+                        <constraint firstAttribute="bottom" secondItem="aLb-EL-GfB" secondAttribute="bottom" constant="10" id="Q8b-Sj-NGy"/>
+                        <constraint firstItem="X8B-Q2-jmd" firstAttribute="leading" secondItem="fLx-PJ-SRJ" secondAttribute="leading" constant="10" id="T2h-3Q-pIi"/>
+                        <constraint firstItem="3WX-Mq-2i1" firstAttribute="top" secondItem="X8B-Q2-jmd" secondAttribute="bottom" constant="15" id="Va4-gg-EQT"/>
+                        <constraint firstItem="3WX-Mq-2i1" firstAttribute="leading" secondItem="fLx-PJ-SRJ" secondAttribute="leading" constant="10" id="VrX-GE-8aU"/>
+                        <constraint firstItem="4pe-9q-UpJ" firstAttribute="centerY" secondItem="qEf-JD-335" secondAttribute="centerY" id="ZDq-Zv-mlz"/>
+                        <constraint firstItem="tkA-TC-4Rx" firstAttribute="trailing" secondItem="4pe-9q-UpJ" secondAttribute="trailing" id="ZJd-M0-FL2"/>
+                        <constraint firstItem="qEf-JD-335" firstAttribute="leading" secondItem="3WX-Mq-2i1" secondAttribute="trailing" constant="10" id="c3D-9V-fZ8"/>
+                        <constraint firstItem="aLb-EL-GfB" firstAttribute="top" secondItem="4pe-9q-UpJ" secondAttribute="bottom" constant="10" id="djG-KQ-TSk"/>
+                        <constraint firstItem="qEf-JD-335" firstAttribute="centerY" secondItem="3WX-Mq-2i1" secondAttribute="centerY" id="rbm-ow-Hr2"/>
+                        <constraint firstItem="4pe-9q-UpJ" firstAttribute="top" secondItem="tkA-TC-4Rx" secondAttribute="bottom" constant="10" id="tEl-0J-eAs"/>
+                    </constraints>
+                </view>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="0kX-Kl-MDd">
+                    <rect key="frame" x="0.0" y="548.5" width="414" height="313.5"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="zNC-ne-17w" userLabel="Line 1">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="78.5"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pnc-fS-OM8">
+                                    <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="1"/>
+                                    <connections>
+                                        <action selector="oneTapped:" destination="-1" eventType="touchUpInside" id="5BC-CP-uUa"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="blA-Xr-rfk">
+                                    <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="2"/>
+                                    <connections>
+                                        <action selector="twoTapped:" destination="-1" eventType="touchUpInside" id="utx-Gh-bXJ"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o0M-UP-Rk5">
+                                    <rect key="frame" x="207" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="3"/>
+                                    <connections>
+                                        <action selector="threeTapped:" destination="-1" eventType="touchUpInside" id="1Cb-AK-rNc"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yad-QF-DSb">
+                                    <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="/"/>
+                                    <connections>
+                                        <action selector="divisionTapped:" destination="-1" eventType="touchUpInside" id="gWA-l5-ydh"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="TVS-ym-BML" userLabel="Line 2">
+                            <rect key="frame" x="0.0" y="78.5" width="414" height="78"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L5d-QI-dZG">
+                                    <rect key="frame" x="0.0" y="0.0" width="103.5" height="78"/>
+                                    <state key="normal" title="4"/>
+                                    <connections>
+                                        <action selector="fourTapped:" destination="-1" eventType="touchUpInside" id="yaW-Ta-KhX"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uqZ-Zx-Nzq">
+                                    <rect key="frame" x="103.5" y="0.0" width="103.5" height="78"/>
+                                    <state key="normal" title="5"/>
+                                    <connections>
+                                        <action selector="fiveTapped:" destination="-1" eventType="touchUpInside" id="uf4-rq-IvF"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TEQ-Wv-51m">
+                                    <rect key="frame" x="207" y="0.0" width="103.5" height="78"/>
+                                    <state key="normal" title="6"/>
+                                    <connections>
+                                        <action selector="sixTapped:" destination="-1" eventType="touchUpInside" id="EiM-iK-2dM"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpW-m6-gJK">
+                                    <rect key="frame" x="310.5" y="0.0" width="103.5" height="78"/>
+                                    <state key="normal" title="*"/>
+                                    <connections>
+                                        <action selector="multiplyTapped:" destination="-1" eventType="touchUpInside" id="j8d-v3-gOR"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="mTC-rY-0q7" userLabel="Line 3">
+                            <rect key="frame" x="0.0" y="156.5" width="414" height="78.5"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eb0-or-e7a">
+                                    <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="7"/>
+                                    <connections>
+                                        <action selector="sevenTapped:" destination="-1" eventType="touchUpInside" id="P9q-gW-gqd"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vDc-72-ZGQ">
+                                    <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="8"/>
+                                    <connections>
+                                        <action selector="eightTapped:" destination="-1" eventType="touchUpInside" id="AZJ-N6-Bsx"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dO6-ES-U6p">
+                                    <rect key="frame" x="207" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="9"/>
+                                    <connections>
+                                        <action selector="nineTapped:" destination="-1" eventType="touchUpInside" id="2IZ-nz-Qtu"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gMU-9A-ueg">
+                                    <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="+"/>
+                                    <connections>
+                                        <action selector="additionTapped:" destination="-1" eventType="touchUpInside" id="aLr-OA-7pa"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="USD-XQ-8mw" userLabel="Line 4">
+                            <rect key="frame" x="0.0" y="235" width="414" height="78.5"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="59c-I8-mls">
+                                    <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="."/>
+                                    <connections>
+                                        <action selector="dotTapped:" destination="-1" eventType="touchUpInside" id="CXa-jw-B1g"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZL6-uO-xEa">
+                                    <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="0"/>
+                                    <connections>
+                                        <action selector="zeroTapped:" destination="-1" eventType="touchUpInside" id="HTC-wu-uR5"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eQy-eq-OGT">
+                                    <rect key="frame" x="207" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" image="return" catalog="system"/>
+                                    <connections>
+                                        <action selector="backTapped:" destination="-1" eventType="touchUpInside" id="Grj-Zy-igZ"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hcc-d6-yrA">
+                                    <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
+                                    <state key="normal" title="-"/>
+                                    <connections>
+                                        <action selector="subtractionTapped:" destination="-1" eventType="touchUpInside" id="h2R-Ek-5hq"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                </stackView>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Uvo-Ni-ty9" userLabel="Line 0">
+                    <rect key="frame" x="0.0" y="503.5" width="414" height="45"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Ea-lC-YV1">
+                            <rect key="frame" x="0.0" y="0.0" width="138" height="45"/>
+                            <state key="normal" title="취소"/>
+                            <connections>
+                                <action selector="cancelButtonTapped:" destination="-1" eventType="touchUpInside" id="gxK-3I-KQc"/>
+                            </connections>
+                        </button>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OXX-qQ-6DH">
+                            <rect key="frame" x="138" y="0.0" width="138" height="45"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-oJ-N8p">
+                            <rect key="frame" x="276" y="0.0" width="138" height="45"/>
+                            <state key="normal" title="저장"/>
+                            <connections>
+                                <action selector="saveButtonTapped:" destination="-1" eventType="touchUpInside" id="XTN-WY-cDN"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="0kX-Kl-MDd" firstAttribute="top" secondItem="Uvo-Ni-ty9" secondAttribute="bottom" id="5dm-zO-9oG"/>
+                <constraint firstItem="fLx-PJ-SRJ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="JPT-bd-AAd"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fLx-PJ-SRJ" secondAttribute="trailing" id="JaW-8O-dJs"/>
+                <constraint firstItem="0kX-Kl-MDd" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.35" id="NK5-JK-lX7"/>
+                <constraint firstItem="Uvo-Ni-ty9" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Q7Q-qd-fTQ"/>
+                <constraint firstItem="Uvo-Ni-ty9" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.05" id="aew-P5-zSc"/>
+                <constraint firstItem="fLx-PJ-SRJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="dht-aF-fyi"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Uvo-Ni-ty9" secondAttribute="trailing" id="fGA-53-mMW"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="0kX-Kl-MDd" secondAttribute="bottom" id="hvk-1c-ZWd"/>
+                <constraint firstItem="0kX-Kl-MDd" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="m7l-qn-khK"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="0kX-Kl-MDd" secondAttribute="trailing" id="yGV-oI-Eax"/>
+            </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <point key="canvasLocation" x="132" y="151"/>
+            <point key="canvasLocation" x="131.8840579710145" y="150.66964285714286"/>
         </view>
     </objects>
     <resources>
+        <image name="return" catalog="system" width="128" height="101"/>
         <namedColor name="DeleteButtonColor">
             <color red="0.98600000143051147" green="0.72399997711181641" blue="0.73100000619888306" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListViewController.swift
@@ -39,9 +39,9 @@ class HistoryListViewController: UIViewController {
     private lazy var headers = setupSection(with: travelItemViewModel?.histories ?? [])
     private lazy var refresher: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
-        refreshControl.tintColor = .black
+        refreshControl.tintColor = .clear
         refreshControl.addTarget(self, action: #selector(addHistory), for: .valueChanged)
-        
+        refreshControl.attributedTitle = NSAttributedString(string: "새 지출 입력하기")
         return refreshControl
     }()
     
@@ -62,8 +62,9 @@ class HistoryListViewController: UIViewController {
 
     @objc private func addHistory() {
         let addHistoryVC = AddHistoryViewController(nibName: AddHistoryViewController.identifier, bundle: nil)
-        self.present(addHistoryVC, animated: true) {
-            print("pull to refresh")
+        addHistoryVC.travelItemViewModel = self.travelItemViewModel
+        self.present(addHistoryVC, animated: true) { [weak self] in
+            self?.refresher.endRefreshing()
         }
     }
     

--- a/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
@@ -104,7 +104,9 @@ extension TravelItemViewModel: HistoryListPresentable {
         histories.removeAll()
         var newHistoryItemViewModels: [HistoryItemViewModel] = []
         fetchedHistories.forEach { history in
-            newHistoryItemViewModels.append(HistoryItemViewModel(history: history))
+            if history.travel?.id == self.id {
+                newHistoryItemViewModels.append(HistoryItemViewModel(history: history))
+            }
         }
         
         histories = newHistoryItemViewModels

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -80,8 +80,7 @@ class PersistenceManagerTests: XCTestCase {
         wait(for: [countryExpectation, travelExpectation], timeout: 5.0)
         
         var createdHistory: History?
-        persistenceManagerStub.createObject(newObjectInfo: historyInfo) {
-            (createdObject) in
+        persistenceManagerStub.createObject(newObjectInfo: historyInfo) { createdObject in
             createdHistory = createdObject as? History
             XCTAssertNotNil(createdHistory)
         }


### PR DESCRIPTION
### Issue Number
Close #123 

### 변경사항
기존에 HistoryListViewController 화면에서 선택된 여행과 상관없이 코어데이터의 모든 History 내역을 받아오던 버그 수정
지출/수입 추가화면 간단한 UI 틀 잡기

### 새로운 기능
지출/수입 내역이 해당된 여행에 대해서만 fetch 되도록 필터됨

### 작업 유형
- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
