### PR TITLE
메모수정 기능 구현

### DIFF
--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -128,17 +128,22 @@ class AddHistoryViewController: UIViewController {
             historyTitleLabel.textColor = .systemGray2
         }
         
-        // 메모
-        if let previousMemo = newHistoryViewModel.memo {
-            self.memo = previousMemo
-        }
-        
         // 날짜
         // TODO: DatePicker로 변경해서 사용자가 날짜를 바꿀 수 있도록 하는 기능 구현하기
         let dateLabelText = newHistoryViewModel.currentDate.convertToString(format: .dotted)
         dateLabel.text = dateLabelText
         
-        // 이미지, 메모 버튼
+        // 이미지
+        if let previousImage = newHistoryViewModel.image {
+            self.image = previousImage
+            self.imageButton.tintColor = .black
+        }
+        
+        // 메모
+        if let previousMemo = newHistoryViewModel.memo {
+            self.memo = previousMemo
+            self.memoButton.tintColor = .black
+        }
         
         // 계산기 버튼 색상
         coloredButtons.forEach { button in
@@ -230,27 +235,35 @@ class AddHistoryViewController: UIViewController {
     }
     
     @IBAction func addMemoButtonTapped(_ sender: Any) {
-        // TODO: - 기존 메모내용 가져갈 수 있도록 present 함수 개선하기
         MemoEditViewController.present(at: self, memoType: .expenseMemo, previousMemo: memo) { [weak self] newMemo in
             // TODO: - 메모 입력확인 toaster
-            self?.memo = newMemo
+            if newMemo.isEmpty {
+                self?.memo = nil
+                self?.memoButton.tintColor = .lightGray
+            } else {
+                self?.memo = newMemo
+                self?.memoButton.tintColor = .black
+            }
         }
     }
     
 }
 
 extension AddHistoryViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
     func imagePickerController(_ picker: UIImagePickerController,
                                didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         
         if let newImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
             self.image = newImage.pngData()
+            self.imageButton.tintColor = .black
         }
         
         dismiss(animated: true) {
             // TODO: - 이미지 추가확인 toaster
         }
     }
+    
 }
 
 // MARK: - Calculator IBActions

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -231,7 +231,7 @@ class AddHistoryViewController: UIViewController {
     
     @IBAction func addMemoButtonTapped(_ sender: Any) {
         // TODO: - 기존 메모내용 가져갈 수 있도록 present 함수 개선하기
-        MemoEditViewController.present(at: self, memoType: .expenseMemo) { [weak self] newMemo in
+        MemoEditViewController.present(at: self, memoType: .expenseMemo, previousMemo: memo) { [weak self] newMemo in
             // TODO: - 메모 입력확인 toaster
             self?.memo = newMemo
         }

--- a/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
@@ -17,7 +17,8 @@ enum EditMemoType: String {
 class MemoEditViewController: UIViewController {
     static let identifier = "MemoEditViewController"
     
-    var saveButtonHandler: ((String) -> Void)?
+    private var saveButtonHandler: ((String) -> Void)?
+    private var memo: String?
     private var memoType: EditMemoType?
     @IBOutlet weak var memoView: UIView!
     @IBOutlet weak var memoTextView: UITextView!
@@ -43,7 +44,7 @@ class MemoEditViewController: UIViewController {
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         dismiss(animated: true) { [weak self] in
-            self?.saveButtonHandler?(self?.memoTextView.text ?? "")
+            self?.saveButtonHandler?(self?.memo ?? "")
         }
     }
     
@@ -52,8 +53,13 @@ class MemoEditViewController: UIViewController {
     }
     
     private func setInitialTextviewPlaceholder() {
-        self.memoTextView.text = memoType?.rawValue
-        if memoTextView.text.isPlaceholder() {
+        if let previousMemo = memo, !previousMemo.isEmpty {
+            // 기존의 메모가 nil이 아니고 빈 문자열이 아닐 때
+            memoTextView.text = previousMemo
+            memoTextView.textColor = .black
+        } else {
+            // 기존의 메모가 없을 때 (Nil)
+            memoTextView.text = memoType?.rawValue
             memoTextView.textColor = .lightGray
         }
     }
@@ -62,9 +68,6 @@ class MemoEditViewController: UIViewController {
         if memoTextView.text.isPlaceholder() {
             memoTextView.text = ""
             memoTextView.textColor = .black
-        } else {
-            memoTextView.text = memoType?.rawValue
-            memoTextView.textColor = .lightGray
         }
     }
 }
@@ -75,6 +78,7 @@ extension MemoEditViewController: UITextViewDelegate {
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
+        memo = textView.text.isPlaceholder() ? "" : textView.text
         if textView.text.isEmpty {
             setTextViewPlaceholder()
         }
@@ -87,12 +91,14 @@ extension MemoEditViewController {
     
     static func present(at viewController: UIViewController,
                         memoType: EditMemoType,
+                        previousMemo: String?,
                         onDismiss: ((String) -> Void)?) {
         
         let storyBoard = UIStoryboard(name: storyboardName, bundle: Bundle.main)
         
         guard let vc = storyBoard.instantiateViewController(withIdentifier: MemoEditViewController.identifier) as? MemoEditViewController else { return }
         
+        vc.memo = previousMemo
         vc.memoType = memoType
         vc.saveButtonHandler = onDismiss
         

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelProfileViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelProfileViewController.swift
@@ -93,7 +93,7 @@ class TravelProfileViewController: UIViewController {
     }
     
     @objc func memoLabelTapped() {
-        MemoEditViewController.present(at: self, memoType: .travelMemo) { [weak self] (newMemo) in
+        MemoEditViewController.present(at: self, memoType: .travelMemo, previousMemo: self.travelItemViewModel?.memo) { [weak self] (newMemo) in
             self?.travelMemoLabel.text = newMemo.isEmpty ? "여행을 위한 메모를 입력해보세요" : newMemo
             self?.profileDelegate?.updateTravel(id: self?.travelItemViewModel?.id, newTitle: self?.travelItemViewModel?.title, newMemo: newMemo, newStartDate: self?.travelItemViewModel?.startDate, newEndDate: self?.travelItemViewModel?.endDate, newCoverImage: self?.travelItemViewModel?.coverImage, newBudget: self?.travelItemViewModel?.budget, newExchangeRate: self?.travelItemViewModel?.exchangeRate)
         }


### PR DESCRIPTION
### Issue Number
Close #151, #156 

### 변경사항
- MemoEditVC의 present 함수를 개선하여 기존의 메모데이터를 사용자에게 보여줄 수 있도록 구현
- 수정 시, 기존의 데이터에 저장된 이미지, 메모가 있다면 아이콘의 tint color 등을 진하게 해서 사용성을 높인다. (지출/예산 추가 시에는 해당사항 없음)

### 새로운 기능
- 기존에 항상 placeholder만 나왔던 메모 수정 화면이 기존의 데이터를 표현할 수 있다.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/35067611/101303720-02deec80-3882-11eb-90dc-c3940b815864.gif)

- 이미지, 메모 아이콘에 색을 입혀 사용성을 높인다
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/35067611/101313983-f1560e80-389a-11eb-8878-7ea3f7c47f7b.gif)

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
