### PR TITLE
Toaster Cocoapod 추가

### DIFF
--- a/BoostPocket/BoostPocket/Models/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/Models/PersistenceManager.swift
@@ -110,7 +110,7 @@ class PersistenceManager: PersistenceManagable {
                 filteredIdentifiers[countryCode] = identifier
             }
         }
-        
+
         return filteredIdentifiers
     }
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Toaster
 
 struct BaseHistoryViewModel {
     // new, edit 모두 필요한 정보
@@ -73,7 +74,6 @@ class AddHistoryViewController: UIViewController {
     
     private func configureViews() {
         guard let newHistoryViewModel = self.baseHistoryViewModel else { return }
-        
         self.isAddingIncome = newHistoryViewModel.isIncome
         
         let color = isAddingIncome ? .systemGreen : UIColor(named: "deleteButtonColor")
@@ -134,6 +134,7 @@ class AddHistoryViewController: UIViewController {
         dateLabel.text = dateLabelText
         
         // 이미지
+        
         if let previousImage = newHistoryViewModel.image {
             self.image = previousImage
             self.imageButton.tintColor = .black
@@ -236,7 +237,9 @@ class AddHistoryViewController: UIViewController {
     
     @IBAction func addMemoButtonTapped(_ sender: Any) {
         MemoEditViewController.present(at: self, memoType: .expenseMemo, previousMemo: memo) { [weak self] newMemo in
-            // TODO: - 메모 입력확인 toaster
+            let memoToast = Toast(text: "메모를 입력했습니다", duration: Delay.short)
+            memoToast.show()
+            
             if newMemo.isEmpty {
                 self?.memo = nil
                 self?.memoButton.tintColor = .lightGray
@@ -255,13 +258,14 @@ extension AddHistoryViewController: UIImagePickerControllerDelegate, UINavigatio
                                didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         
         if let newImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+            let imageToast = Toast(text: "사진을 추가했습니다", duration: Delay.short)
+            imageToast.show()
+            
             self.image = newImage.pngData()
             self.imageButton.tintColor = .black
         }
         
-        dismiss(animated: true) {
-            // TODO: - 이미지 추가확인 toaster
-        }
+        dismiss(animated: true)
     }
     
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListViewController.swift
@@ -186,7 +186,7 @@ class HistoryListViewController: UIViewController {
         
         let saveButtonHandler: ((NewHistoryData) -> Void)? = { [weak self] newHistoryData in
             // isPrepare은 현재 "준비" 버튼이 선택되었는지에 따라 true/false
-            self?.travelItemViewModel?.createHistory(id: UUID(), isIncome: isIncome, title: newHistoryData.title, memo: newHistoryData.memo, date: newHistoryData.date, image: newHistoryData.image ?? Data(), amount: newHistoryData.amount, category: newHistoryData.category, isPrepare: self?.isPrepareOnly ?? false, isCard: newHistoryData.isCard ?? false) { _ in }
+            self?.travelItemViewModel?.createHistory(id: UUID(), isIncome: isIncome, title: newHistoryData.title, memo: newHistoryData.memo, date: newHistoryData.date, image: newHistoryData.image, amount: newHistoryData.amount, category: newHistoryData.category, isPrepare: self?.isPrepareOnly ?? false, isCard: newHistoryData.isCard ?? false) { _ in }
         }
         
         let onPresent: (() -> Void)  = { [weak self] in

--- a/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
@@ -73,7 +73,7 @@ class TravelItemViewModel: TravelItemPresentable, Equatable, Hashable {
 protocol HistoryListPresentable: TravelItemPresentable {
     var histories: [HistoryItemViewModel] { get }
     var didFetch: (([HistoryItemViewModel]) -> Void)? { get set }
-    func createHistory(id: UUID, isIncome: Bool, title: String, memo: String?, date: Date?, image: Data, amount: Double,
+    func createHistory(id: UUID, isIncome: Bool, title: String, memo: String?, date: Date?, image: Data?, amount: Double,
                        category: HistoryCategory, isPrepare: Bool, isCard: Bool, completion: @escaping (HistoryItemViewModel?) -> Void)
     func needFetchItems()
     func updateHistory(id: UUID, isIncome: Bool, title: String, memo: String?, date: Date?, image: Data?, amount: Double, category: HistoryCategory, isPrepare: Bool?, isCard: Bool?) -> Bool
@@ -83,7 +83,7 @@ protocol HistoryListPresentable: TravelItemPresentable {
 
 extension TravelItemViewModel: HistoryListPresentable {
     
-    func createHistory(id: UUID, isIncome: Bool, title: String, memo: String?, date: Date?, image: Data, amount: Double, category: HistoryCategory, isPrepare: Bool, isCard: Bool, completion: @escaping (HistoryItemViewModel?) -> Void) {
+    func createHistory(id: UUID, isIncome: Bool, title: String, memo: String?, date: Date?, image: Data?, amount: Double, category: HistoryCategory, isPrepare: Bool, isCard: Bool, completion: @escaping (HistoryItemViewModel?) -> Void) {
         
         let historyInfo = HistoryInfo(travelId: self.id ?? UUID(), id: id, isIncome: isIncome, title: title, memo: memo, date: date ?? Date(), category: category, amount: amount, image: image, isPrepare: isPrepare, isCard: isCard)
         

--- a/BoostPocket/Podfile
+++ b/BoostPocket/Podfile
@@ -8,8 +8,9 @@ target 'BoostPocket' do
 
   # Pods for BoostPocket
   pod 'SwiftLint'
-  pod 'FlagKit'  
-
+  pod 'FlagKit'
+  pod 'Toaster', :git => 'https://github.com/devxoul/Toaster.git', :branch => 'master'
+  
   target 'BoostPocketTests' do
     inherit! :search_paths
     # Pods for testing

--- a/BoostPocket/Podfile.lock
+++ b/BoostPocket/Podfile.lock
@@ -1,20 +1,33 @@
 PODS:
   - FlagKit (2.2)
   - SwiftLint (0.41.0)
+  - Toaster (2.3.0)
 
 DEPENDENCIES:
   - FlagKit
   - SwiftLint
+  - Toaster (from `https://github.com/devxoul/Toaster.git`, branch `master`)
 
 SPEC REPOS:
   trunk:
     - FlagKit
     - SwiftLint
 
+EXTERNAL SOURCES:
+  Toaster:
+    :branch: master
+    :git: https://github.com/devxoul/Toaster.git
+
+CHECKOUT OPTIONS:
+  Toaster:
+    :commit: 0fca711c4083cb921cc0893a7a47836358ebf96b
+    :git: https://github.com/devxoul/Toaster.git
+
 SPEC CHECKSUMS:
   FlagKit: eca7dc89064b0c986302ba9acefad1bf80a435b1
   SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  Toaster: c3473963c78e8cabbf6ea6f11ad0fdaae6f54987
 
-PODFILE CHECKSUM: 2d25cae3f5d84ceeec004d700191ef538d1440d7
+PODFILE CHECKSUM: 6cc7f66c6b8ad0a94cbe8ad06e2be83f241964d8
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
### Issue Number
Close #155 

### 변경사항
- Toaster를 추가하여 지출/예산에서 메모나 이미지 추가 시 토스트 메세지로 사용성 높임
- TravelItemViewModel의 createHistory 함수가 image를 Data?가 아닌 Data 타입으로
  받던 오류 수정

### 새로운 기능
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/35067611/101318577-e9e73300-38a3-11eb-8e8d-7a8be0fd7946.gif)


### 작업 유형
- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
