### PR TITLE
Country Entity에 identifier attribute 추가

### DIFF
--- a/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
+++ b/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
@@ -35,14 +35,14 @@
 		5CB682E5256C03F800830373 /* CountryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB682E4256C03F800830373 /* CountryListViewModel.swift */; };
 		5CCB1265257DFF1D00C6788E /* HistoryItemViewModelStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CCB1264257DFF1D00C6788E /* HistoryItemViewModelStub.swift */; };
 		5CD76E9F256C24DC00BD6CE3 /* BoostPocket.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E8225664DBE0007810C /* BoostPocket.xcdatamodeld */; };
-		5CD76EB7256C933C00BD6CE3 /* Country+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9572F9A1256B8FBA003049CB /* Country+CoreDataClass.swift */; };
-		5CD76EBB256C935E00BD6CE3 /* Country+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9572F9A2256B8FBA003049CB /* Country+CoreDataProperties.swift */; };
 		5CD76EBF256C938D00BD6CE3 /* BoostPocket.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E8225664DBE0007810C /* BoostPocket.xcdatamodeld */; };
 		5CD9A895257DCA2300A7AEFF /* HistoryFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD9A894257DCA2300A7AEFF /* HistoryFilter.swift */; };
 		5CD9A89A257DCD6C00A7AEFF /* HistoryFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD9A899257DCD6C00A7AEFF /* HistoryFilterTests.swift */; };
 		5CF409482575239200351F4B /* MemoEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF409472575239200351F4B /* MemoEditViewController.swift */; };
 		954F7019256D1C4B00B2E48B /* TravelListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F7018256D1C4B00B2E48B /* TravelListViewModel.swift */; };
 		954F701B256D3E7700B2E48B /* Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F701A256D3E7700B2E48B /* Sections.swift */; };
+		955555AA257E18A200CA81C9 /* Country+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955555A8257E18A200CA81C9 /* Country+CoreDataClass.swift */; };
+		955555AB257E18A200CA81C9 /* Country+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955555A9257E18A200CA81C9 /* Country+CoreDataProperties.swift */; };
 		9564EE9A257BBE3F00AD85AC /* Character+isOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9564EE99257BBE3F00AD85AC /* Character+isOperation.swift */; };
 		956BBC58256B9CCC007803B1 /* CountryStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956BBC57256B9CCC007803B1 /* CountryStub.swift */; };
 		9572F977256B5397003049CB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 9572F976256B5397003049CB /* .swiftlint.yml */; };
@@ -172,6 +172,8 @@
 		9381276269F50AEF5C02E72C /* Pods-BoostPocket.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BoostPocket.debug.xcconfig"; path = "Target Support Files/Pods-BoostPocket/Pods-BoostPocket.debug.xcconfig"; sourceTree = "<group>"; };
 		954F7018256D1C4B00B2E48B /* TravelListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewModel.swift; sourceTree = "<group>"; };
 		954F701A256D3E7700B2E48B /* Sections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sections.swift; sourceTree = "<group>"; };
+		955555A8257E18A200CA81C9 /* Country+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Country+CoreDataClass.swift"; path = "BoostPocket/CoreDataModels/Country+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
+		955555A9257E18A200CA81C9 /* Country+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Country+CoreDataProperties.swift"; path = "BoostPocket/CoreDataModels/Country+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
 		9564EE99257BBE3F00AD85AC /* Character+isOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+isOperation.swift"; sourceTree = "<group>"; };
 		956BBC57256B9CCC007803B1 /* CountryStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryStub.swift; sourceTree = "<group>"; };
 		9572F976256B5397003049CB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -182,8 +184,6 @@
 		9572F98C256B54E4003049CB /* NetworkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerTests.swift; sourceTree = "<group>"; };
 		9572F98E256B54E4003049CB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9572F99B256B552E003049CB /* DataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataLoader.swift; sourceTree = "<group>"; };
-		9572F9A1256B8FBA003049CB /* Country+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Country+CoreDataClass.swift"; sourceTree = "<group>"; };
-		9572F9A2256B8FBA003049CB /* Country+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Country+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		9572F9A8256B902C003049CB /* PersistenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
 		9572F9AD256B9524003049CB /* CountryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryProvider.swift; sourceTree = "<group>"; };
 		9572F9AF256B9703003049CB /* CountryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryProviderTests.swift; sourceTree = "<group>"; };
@@ -295,12 +295,12 @@
 		9572F99E256B8F42003049CB /* CoreDataModels */ = {
 			isa = PBXGroup;
 			children = (
+				955555A8257E18A200CA81C9 /* Country+CoreDataClass.swift */,
+				955555A9257E18A200CA81C9 /* Country+CoreDataProperties.swift */,
 				A99E062D257762520014C29F /* History+CoreDataClass.swift */,
 				A99E062E257762520014C29F /* History+CoreDataProperties.swift */,
 				A9BF7A6F256E2D5900496CD8 /* Travel+CoreDataClass.swift */,
 				A9BF7A70256E2D5900496CD8 /* Travel+CoreDataProperties.swift */,
-				9572F9A1256B8FBA003049CB /* Country+CoreDataClass.swift */,
-				9572F9A2256B8FBA003049CB /* Country+CoreDataProperties.swift */,
 			);
 			path = CoreDataModels;
 			sourceTree = "<group>";
@@ -819,7 +819,6 @@
 				95747A67256FAF6B0065C419 /* TravelDetailTabbarController.swift in Sources */,
 				9574ACD02578B4C10072C578 /* AddHistoryViewController.swift in Sources */,
 				9579CBB7256E46A900E74A61 /* DataModelInfo.swift in Sources */,
-				5CD76EBB256C935E00BD6CE3 /* Country+CoreDataProperties.swift in Sources */,
 				5C77958D257965B400A685FB /* UIStackView+RemoveAll.swift in Sources */,
 				5C3DAF2F2566576000178EA0 /* CountryListViewController.swift in Sources */,
 				9564EE9A257BBE3F00AD85AC /* Character+isOperation.swift in Sources */,
@@ -837,13 +836,13 @@
 				A9BF7AA5256F9B8800496CD8 /* Date+ConvertToString.swift in Sources */,
 				5C3DAF3525665F0200178EA0 /* CountryCell.swift in Sources */,
 				A99E0646257766F50014C29F /* HistoryItemViewModel.swift in Sources */,
-				5CD76EB7256C933C00BD6CE3 /* Country+CoreDataClass.swift in Sources */,
 				5C4E1B0C256BD7CD006760EF /* CountryItemViewModel.swift in Sources */,
 				A9BF7A37256D496C00496CD8 /* String+firstConsonant.swift in Sources */,
 				95747A69256FCEEA0065C419 /* Data+ImageData.swift in Sources */,
 				5C797493256FD263007CB1ED /* TravelHeaderCell.swift in Sources */,
 				954F7019256D1C4B00B2E48B /* TravelListViewModel.swift in Sources */,
 				A99E067A257DFC580014C29F /* String+CurrencySymbol.swift in Sources */,
+				955555AB257E18A200CA81C9 /* Country+CoreDataProperties.swift in Sources */,
 				5C7F83682578C77A00A58112 /* Date+PeriodOfDates.swift in Sources */,
 				A9BF7A71256E2D5900496CD8 /* Travel+CoreDataClass.swift in Sources */,
 				A99E062F257762520014C29F /* History+CoreDataClass.swift in Sources */,
@@ -857,6 +856,7 @@
 				A99E0630257762520014C29F /* History+CoreDataProperties.swift in Sources */,
 				A9BF7A86256F420D00496CD8 /* TravelCell.swift in Sources */,
 				A99E06652578D6480014C29F /* HistoryDetailViewController.swift in Sources */,
+				955555AA257E18A200CA81C9 /* Country+CoreDataClass.swift in Sources */,
 				95A42E7C25664DBE0007810C /* SceneDelegate.swift in Sources */,
 				A99E0613257534F10014C29F /* TitleEditViewController.swift in Sources */,
 				5C15AB442577C96E00244C6C /* HistoryListViewController.swift in Sources */,

--- a/BoostPocket/BoostPocket/BoostPocket.xcdatamodeld/BoostPocket.xcdatamodel/contents
+++ b/BoostPocket/BoostPocket/BoostPocket.xcdatamodeld/BoostPocket.xcdatamodel/contents
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="19H2" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Country" representedClassName=".Country" syncable="YES">
         <attribute name="currencyCode" attributeType="String"/>
         <attribute name="exchangeRate" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="flagImage" attributeType="Binary"/>
+        <attribute name="identifier" attributeType="String"/>
         <attribute name="lastUpdated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
         <relationship name="travels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Travel" inverseName="country" inverseEntity="Travel"/>
@@ -34,7 +35,7 @@
         <relationship name="history" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="History" inverseName="travel" inverseEntity="History"/>
     </entity>
     <elements>
-        <element name="Country" positionX="139.05078125" positionY="-38.7421875" width="128" height="133"/>
+        <element name="Country" positionX="139.05078125" positionY="-38.7421875" width="128" height="148"/>
         <element name="History" positionX="145.828125" positionY="167.3515625" width="128" height="208"/>
         <element name="Travel" positionX="-63" positionY="-18" width="128" height="193"/>
     </elements>

--- a/BoostPocket/BoostPocket/CoreDataModels/Country+CoreDataClass.swift
+++ b/BoostPocket/BoostPocket/CoreDataModels/Country+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  Country+CoreDataClass.swift
 //  BoostPocket
 //
-//  Created by sihyung you on 2020/11/23.
+//  Created by sihyung you on 2020/12/07.
 //  Copyright © 2020 BoostPocket. All rights reserved.
 //
 //

--- a/BoostPocket/BoostPocket/CoreDataModels/Country+CoreDataProperties.swift
+++ b/BoostPocket/BoostPocket/CoreDataModels/Country+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Country+CoreDataProperties.swift
 //  BoostPocket
 //
-//  Created by sihyung you on 2020/11/23.
+//  Created by sihyung you on 2020/12/07.
 //  Copyright © 2020 BoostPocket. All rights reserved.
 //
 //
@@ -10,17 +10,19 @@
 import Foundation
 import CoreData
 
+
 extension Country {
 
     @nonobjc public class func fetchRequest() -> NSFetchRequest<Country> {
         return NSFetchRequest<Country>(entityName: "Country")
     }
 
-    @NSManaged public var name: String?
+    @NSManaged public var currencyCode: String?
     @NSManaged public var exchangeRate: Double
     @NSManaged public var flagImage: Data?
     @NSManaged public var lastUpdated: Date?
-    @NSManaged public var currencyCode: String?
+    @NSManaged public var name: String?
+    @NSManaged public var identifier: String?
     @NSManaged public var travels: NSSet?
 
 }

--- a/BoostPocket/BoostPocket/CountryListScene/CountryListViewModel.swift
+++ b/BoostPocket/BoostPocket/CountryListScene/CountryListViewModel.swift
@@ -13,8 +13,6 @@ protocol CountryListPresentable: AnyObject {
     var didFetch: (([CountryItemViewModel]) -> Void)? { get set }
     
     func needFetchItems()
-    // func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String)
-    func cellForItemAt(path: IndexPath) -> CountryItemViewModel
     func numberOfItem() -> Int
 }
 
@@ -41,21 +39,6 @@ class CountryListViewModel: CountryListPresentable {
             newCountryItemViewModels.append(CountryItemViewModel(country: country))
         }
         countries = newCountryItemViewModels
-    }
-    
-    /*
-    func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String) {
-        countryProvider?.createCountry(name: name, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode) { [weak self] (createdCountry) in
-            guard let createdCountry = createdCountry else { return }
-            
-            let createdCountryItemViewModel = CountryItemViewModel(country: createdCountry)
-            self?.countries.append(createdCountryItemViewModel)
-        }
-    }
-     */
-    
-    func cellForItemAt(path: IndexPath) -> CountryItemViewModel {
-        return countries[path.row]
     }
     
     func numberOfItem() -> Int {

--- a/BoostPocket/BoostPocket/CountryListScene/CountryListViewModel.swift
+++ b/BoostPocket/BoostPocket/CountryListScene/CountryListViewModel.swift
@@ -13,7 +13,7 @@ protocol CountryListPresentable: AnyObject {
     var didFetch: (([CountryItemViewModel]) -> Void)? { get set }
     
     func needFetchItems()
-    func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String)
+    // func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String)
     func cellForItemAt(path: IndexPath) -> CountryItemViewModel
     func numberOfItem() -> Int
 }
@@ -43,6 +43,7 @@ class CountryListViewModel: CountryListPresentable {
         countries = newCountryItemViewModels
     }
     
+    /*
     func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String) {
         countryProvider?.createCountry(name: name, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode) { [weak self] (createdCountry) in
             guard let createdCountry = createdCountry else { return }
@@ -51,6 +52,7 @@ class CountryListViewModel: CountryListPresentable {
             self?.countries.append(createdCountryItemViewModel)
         }
     }
+     */
     
     func cellForItemAt(path: IndexPath) -> CountryItemViewModel {
         return countries[path.row]

--- a/BoostPocket/BoostPocket/CountryListScene/CountryProvider.swift
+++ b/BoostPocket/BoostPocket/CountryListScene/CountryProvider.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol CountryProvidable: AnyObject {
     var countries: [Country] { get }
     func fetchCountries() -> [Country]
-    func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String, completion: @escaping (Country?) -> Void)
+    // func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String, completion: @escaping (Country?) -> Void)
 }
 
 class CountryProvider: CountryProvidable {
@@ -32,12 +32,15 @@ class CountryProvider: CountryProvidable {
         return countries
     }
     
+    /*
     func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String, completion: @escaping (Country?) -> Void) {
         let newCountryInfo = CountryInfo(name: name,
                                          lastUpdated: lastUpdated,
                                          flagImage: flagImage,
                                          exchangeRate: exchangeRate,
-                                         currencyCode: currencyCode)
+                                         currencyCode: currencyCode,
+                                         identifier: <#String#>)
+        
         persistenceManager?.createObject(newObjectInfo: newCountryInfo, completion: { (createdObject) in
             guard let createdCountry = createdObject as? Country else {
                 completion(nil)
@@ -46,4 +49,5 @@ class CountryProvider: CountryProvidable {
             completion(createdCountry)
         })
     }
+    */
 }

--- a/BoostPocket/BoostPocket/Models/DataModelInfo.swift
+++ b/BoostPocket/BoostPocket/Models/DataModelInfo.swift
@@ -14,13 +14,15 @@ struct CountryInfo {
     private(set) var flagImage: Data
     private(set) var currencyCode: String
     private(set) var exchangeRate: Double
+    private(set) var identifier: String
     
-    init(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String ) {
+    init(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String, identifier: String) {
         self.name = name
         self.lastUpdated = lastUpdated
         self.flagImage = flagImage
         self.currencyCode = currencyCode
         self.exchangeRate = exchangeRate
+        self.identifier = identifier
     }
 }
 

--- a/BoostPocket/BoostPocket/Models/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/Models/PersistenceManager.swift
@@ -93,7 +93,7 @@ class PersistenceManager: PersistenceManagable {
                 dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
                 let date: Date = dateFormatter.date(from: data.date) ?? Date()
                 
-                createObject(newObjectInfo: CountryInfo(name: countryName, lastUpdated: date, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode)) { _ in }
+                createObject(newObjectInfo: CountryInfo(name: countryName, lastUpdated: date, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier)) { _ in }
             }
         }
     }
@@ -185,6 +185,7 @@ extension PersistenceManager {
         guard let entity = NSEntityDescription.entity(forEntityName: Country.entityName, in: self.context) else { return nil }
         let newCountry = Country(entity: entity, insertInto: context)
         
+        newCountry.identifier = countryInfo.identifier
         newCountry.name = countryInfo.name
         newCountry.lastUpdated = countryInfo.lastUpdated
         newCountry.flagImage = countryInfo.flagImage
@@ -234,8 +235,11 @@ extension PersistenceManager {
                     if let countryName = fetchedCountry.name,
                         let flagImage = fetchedCountry.flagImage,
                         let currencyCode = fetchedCountry.currencyCode,
-                        self?.updateObject(updatedObjectInfo: CountryInfo(name: countryName, lastUpdated: newLastUpdated, flagImage: flagImage, exchangeRate: newExchangeRate, currencyCode: currencyCode)) != nil {
+                        let identifier = fetchedCountry.identifier,
+                        self?.updateObject(updatedObjectInfo: CountryInfo(name: countryName, lastUpdated: newLastUpdated, flagImage: flagImage, exchangeRate: newExchangeRate, currencyCode: currencyCode, identifier: identifier)) != nil {
                         print("환율 정보 업데이트 성공")
+                    } else {
+                        print("환율 정보 업데이트 실패")
                     }
                     
                 case .failure(let error):

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -25,6 +25,7 @@ struct BaseHistoryViewModel {
     var amount: Double?
     // 상세화면
     var isPrepare: Bool?
+    var countryIdentifier: String?
 }
 
 struct NewHistoryData {

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailViewController.swift
@@ -36,7 +36,7 @@ class HistoryDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         imagePicker.delegate = self
         
         let titleTap = UITapGestureRecognizer(target: self, action: #selector(titleLabelTapped))
@@ -68,8 +68,7 @@ class HistoryDetailViewController: UIViewController {
         // TO-DO : 값 업데이트
     }
     
-    func configureViews(history: BaseHistoryViewModel) {
-        
+    func configureViews(history: BaseHistoryViewModel) {        
         expanseStackView.translatesAutoresizingMaskIntoConstraints = false
         incomeStackView.translatesAutoresizingMaskIntoConstraints = false
         buttonStackView.translatesAutoresizingMaskIntoConstraints = false

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListViewController.swift
@@ -332,7 +332,8 @@ extension HistoryListViewController: UITableViewDelegate {
                                                         memo: selectedHistoryViewModel.memo,
                                                         image: selectedHistoryViewModel.image,
                                                         amount: selectedHistoryViewModel.amount,
-                                                        isPrepare: selectedHistoryViewModel.isPrepare)
+                                                        isPrepare: selectedHistoryViewModel.isPrepare,
+                                                        countryIdentifier: travelItemViewModel?.countryIdentifier)
             
             self.present(historyDetailVC, animated: true, completion: nil)
             historyDetailVC.configureViews(history: detailhistoryViewModel)

--- a/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
@@ -20,6 +20,7 @@ protocol TravelItemPresentable: AnyObject {
     var countryName: String? { get }
     var flagImage: Data? { get }
     var currencyCode: String? { get }
+    var countryIdentifier: String? { get }
 }
 
 class TravelItemViewModel: TravelItemPresentable, Equatable, Hashable {
@@ -52,6 +53,7 @@ class TravelItemViewModel: TravelItemPresentable, Equatable, Hashable {
     var countryName: String?
     var flagImage: Data?
     var currencyCode: String?
+    var countryIdentifier: String?
     
     init(travel: TravelProtocol, historyProvider: HistoryProvidable) {
         self.id = travel.id
@@ -65,6 +67,7 @@ class TravelItemViewModel: TravelItemPresentable, Equatable, Hashable {
         self.countryName = travel.country?.name
         self.flagImage = travel.country?.flagImage
         self.currencyCode = travel.country?.currencyCode
+        self.countryIdentifier = travel.country?.identifier
         
         self.historyProvider = historyProvider
     }

--- a/BoostPocket/BoostPocketTests/CountryTests/CountryProviderTests.swift
+++ b/BoostPocket/BoostPocketTests/CountryTests/CountryProviderTests.swift
@@ -13,19 +13,20 @@ import NetworkManager
 class CountryProviderTests: XCTestCase {
     
     var persistenceManagerStub: PersistenceManagable!
-    var countryProviderStub: CountryProvidable!
+    var countryProviderStub: CountryProviderStub!
     
     let countryName = "test name"
     let lastUpdated = "2019-08-23-12-01-33".convertToDate()
     let flagImage = Data()
     let exchangeRate = 1.5
     let currencyCode = "test code"
+    let identifier = "ko_KR"
     
     override func setUpWithError() throws {
         let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
         let dataLoader = DataLoader(session: session)
         persistenceManagerStub = PersistenceManagerStub(dataLoader: dataLoader)
-        countryProviderStub = CountryProvider(persistenceManager: persistenceManagerStub)
+        countryProviderStub = CountryProviderStub(persistenceManager: persistenceManagerStub)
     }
 
     override func tearDownWithError() throws {
@@ -38,7 +39,7 @@ class CountryProviderTests: XCTestCase {
         
         XCTAssertEqual(countryProviderStub.fetchCountries(), [])
         
-        countryProviderStub.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode) { (country) in
+        countryProviderStub.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier) { (country) in
             XCTAssertNotNil(country)
             expectation.fulfill()
         }
@@ -51,7 +52,7 @@ class CountryProviderTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Successfully Created Country")
         var createdCountry: Country?
         
-        countryProviderStub.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode) { (country) in
+        countryProviderStub.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier) { (country) in
             XCTAssertNotNil(country)
             createdCountry = country
             expectation.fulfill()

--- a/BoostPocket/BoostPocketTests/CountryTests/CountryStub.swift
+++ b/BoostPocket/BoostPocketTests/CountryTests/CountryStub.swift
@@ -23,12 +23,12 @@ class CountryStub: CountryProtocol {
 
 class CountryProviderStub: CountryProvider {
     private weak var persistenceManager: PersistenceManagable?
-    
+
     override init(persistenceManager: PersistenceManagable) {
         super.init(persistenceManager: persistenceManager)
         self.persistenceManager = persistenceManager
     }
-    
+
     func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String, identifier: String, completion: @escaping (Country?) -> Void) {
         let newCountryInfo = CountryInfo(name: name,
                                          lastUpdated: lastUpdated,
@@ -36,7 +36,7 @@ class CountryProviderStub: CountryProvider {
                                          exchangeRate: exchangeRate,
                                          currencyCode: currencyCode,
                                          identifier: identifier)
-        
+
         persistenceManager?.createObject(newObjectInfo: newCountryInfo, completion: { (createdObject) in
             guard let createdCountry = createdObject as? Country else {
                 completion(nil)
@@ -49,12 +49,12 @@ class CountryProviderStub: CountryProvider {
 
 class CountryListViewModelStub: CountryListViewModel {
     var countryProvider: CountryProviderStub?
-    
+
     override init(countryProvider: CountryProvidable) {
         super.init(countryProvider: countryProvider)
         self.countryProvider = countryProvider as? CountryProviderStub
     }
-    
+
     func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String, identifier: String) {
         countryProvider?.createCountry(name: name, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier) { [weak self] (createdCountry) in
             guard let createdCountry = createdCountry else { return }

--- a/BoostPocket/BoostPocketTests/CountryTests/CountryStub.swift
+++ b/BoostPocket/BoostPocketTests/CountryTests/CountryStub.swift
@@ -20,3 +20,47 @@ class CountryStub: CountryProtocol {
         self.currencyCode = currencyCode
     }
 }
+
+class CountryProviderStub: CountryProvider {
+    private weak var persistenceManager: PersistenceManagable?
+    
+    override init(persistenceManager: PersistenceManagable) {
+        super.init(persistenceManager: persistenceManager)
+        self.persistenceManager = persistenceManager
+    }
+    
+    func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String, identifier: String, completion: @escaping (Country?) -> Void) {
+        let newCountryInfo = CountryInfo(name: name,
+                                         lastUpdated: lastUpdated,
+                                         flagImage: flagImage,
+                                         exchangeRate: exchangeRate,
+                                         currencyCode: currencyCode,
+                                         identifier: identifier)
+        
+        persistenceManager?.createObject(newObjectInfo: newCountryInfo, completion: { (createdObject) in
+            guard let createdCountry = createdObject as? Country else {
+                completion(nil)
+                return
+            }
+            completion(createdCountry)
+        })
+    }
+}
+
+class CountryListViewModelStub: CountryListViewModel {
+    var countryProvider: CountryProviderStub?
+    
+    override init(countryProvider: CountryProvidable) {
+        super.init(countryProvider: countryProvider)
+        self.countryProvider = countryProvider as? CountryProviderStub
+    }
+    
+    func createCountry(name: String, lastUpdated: Date, flagImage: Data, exchangeRate: Double, currencyCode: String, identifier: String) {
+        countryProvider?.createCountry(name: name, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier) { [weak self] (createdCountry) in
+            guard let createdCountry = createdCountry else { return }
+            
+            let createdCountryItemViewModel = CountryItemViewModel(country: createdCountry)
+            self?.countries.append(createdCountryItemViewModel)
+        }
+    }
+}

--- a/BoostPocket/BoostPocketTests/CountryTests/CountryViewModelTests.swift
+++ b/BoostPocket/BoostPocketTests/CountryTests/CountryViewModelTests.swift
@@ -57,18 +57,6 @@ class CountryViewModelTests: XCTestCase {
         XCTAssertEqual(createdCountry?.currencyCode, currencyCode)
     }
     
-    // 없애는 함수
-    func test_countryListViewModel_cellForItemAt() {
-        XCTAssertNotNil(countryListViewModel.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier))
-        
-        let countryItemViewModel = countryListViewModel.cellForItemAt(path: IndexPath(row: 0, section: 0))
-        
-        XCTAssertEqual(countryItemViewModel, countryListViewModel.countries.first)
-        XCTAssertEqual(countryItemViewModel.name, countryName)
-        XCTAssertEqual(countryItemViewModel.flag, flagImage)
-        XCTAssertEqual(countryItemViewModel.currencyCode, currencyCode)
-    }
-    
     func test_countryListViewModel_numberOfItem() {
         countryListViewModel.createCountry(name: "\(countryName)1", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 0.0, currencyCode: "\(currencyCode)1", identifier: identifier)
         countryListViewModel.createCountry(name: "\(countryName)2", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 1.0, currencyCode: "\(currencyCode)2", identifier: identifier)

--- a/BoostPocket/BoostPocketTests/CountryTests/CountryViewModelTests.swift
+++ b/BoostPocket/BoostPocketTests/CountryTests/CountryViewModelTests.swift
@@ -12,22 +12,23 @@ import NetworkManager
 
 class CountryViewModelTests: XCTestCase {
     
-    var countryListViewModel: CountryListPresentable!
+    var countryListViewModel: CountryListViewModelStub!
     var persistenceManager: PersistenceManagable!
-    var countryProvider: CountryProvidable!
+    var countryProvider: CountryProviderStub!
     
     let countryName = "test name"
     let lastUpdated = "2019-08-23-12-01-33".convertToDate()
     let flagImage = Data()
     let exchangeRate = 1.5
     let currencyCode = "test code"
+    let identifier = "ko_KR"
     
     override func setUpWithError() throws {
         let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
         let dataLoader = DataLoader(session: session)
         persistenceManager = PersistenceManagerStub(dataLoader: dataLoader)
-        countryProvider = CountryProvider(persistenceManager: persistenceManager)
-        countryListViewModel = CountryListViewModel(countryProvider: countryProvider)
+        countryProvider = CountryProviderStub(persistenceManager: persistenceManager)
+        countryListViewModel = CountryListViewModelStub(countryProvider: countryProvider)
     }
     
     override func tearDownWithError() throws {
@@ -47,7 +48,7 @@ class CountryViewModelTests: XCTestCase {
     }
     
     func test_countryListViewModel_createCountry() {
-        countryListViewModel.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode)
+        countryListViewModel.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier)
         
         let createdCountry = countryListViewModel.countries.first
         XCTAssertNotNil(createdCountry)
@@ -58,7 +59,7 @@ class CountryViewModelTests: XCTestCase {
     
     // 없애는 함수
     func test_countryListViewModel_cellForItemAt() {
-        XCTAssertNotNil(countryListViewModel.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode))
+        XCTAssertNotNil(countryListViewModel.createCountry(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier))
         
         let countryItemViewModel = countryListViewModel.cellForItemAt(path: IndexPath(row: 0, section: 0))
         
@@ -69,9 +70,9 @@ class CountryViewModelTests: XCTestCase {
     }
     
     func test_countryListViewModel_numberOfItem() {
-        countryListViewModel.createCountry(name: "\(countryName)1", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 0.0, currencyCode: "\(currencyCode)1")
-        countryListViewModel.createCountry(name: "\(countryName)2", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 1.0, currencyCode: "\(currencyCode)2")
-        countryListViewModel.createCountry(name: "\(countryName)3", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 2.0, currencyCode: "\(currencyCode)3")
+        countryListViewModel.createCountry(name: "\(countryName)1", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 0.0, currencyCode: "\(currencyCode)1", identifier: identifier)
+        countryListViewModel.createCountry(name: "\(countryName)2", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 1.0, currencyCode: "\(currencyCode)2", identifier: identifier)
+        countryListViewModel.createCountry(name: "\(countryName)3", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 2.0, currencyCode: "\(currencyCode)3", identifier: identifier)
         
         XCTAssertEqual(countryListViewModel.numberOfItem(), 3)
     }
@@ -79,7 +80,7 @@ class CountryViewModelTests: XCTestCase {
     func test_countryListViewModel_needFetchItem() {
         let expectation = XCTestExpectation(description: "Successfully Created Country")
         
-        countryProvider.createCountry(name: "\(countryName)가", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 0.0, currencyCode: "\(currencyCode)1") { (country) in
+        countryProvider.createCountry(name: "\(countryName)가", lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: 0.0, currencyCode: "\(currencyCode)1", identifier: identifier) { (country) in
             XCTAssertNotNil(country)
             expectation.fulfill()
         }

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -30,12 +30,13 @@ class PersistenceManagerTests: XCTestCase {
     let flagImage = Data()
     let currencyCode = "KRW"
     let historyId = UUID()
+    let identifier = "ko_KR"
     
     override func setUpWithError() throws {
         let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
         let dataLoader = DataLoader(session: session)
         persistenceManagerStub = PersistenceManagerStub(dataLoader: dataLoader)
-        countryInfo = CountryInfo(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode)
+        countryInfo = CountryInfo(name: countryName, lastUpdated: lastUpdated, flagImage: flagImage, exchangeRate: exchangeRate, currencyCode: currencyCode, identifier: identifier)
         travelInfo = TravelInfo(countryName: countryName, id: id, title: countryName, memo: memo, startDate: startDate, endDate: endDate, coverImage: coverImage, budget: budget, exchangeRate: exchangeRate)
         historyInfo = HistoryInfo(travelId: id, id: historyId, isIncome: false, title: "식당", memo: nil, date: Date(), category: .food, amount: Double(), image: nil, isPrepare: nil, isCard: nil)
         
@@ -178,7 +179,7 @@ class PersistenceManagerTests: XCTestCase {
         
         let newLastUpdated = "2020-12-25-12-01-00".convertToDate()
         let newExchagneRate = 12.0
-        countryInfo = CountryInfo(name: countryName, lastUpdated: newLastUpdated, flagImage: flagImage, exchangeRate: newExchagneRate, currencyCode: currencyCode)
+        countryInfo = CountryInfo(name: countryName, lastUpdated: newLastUpdated, flagImage: flagImage, exchangeRate: newExchagneRate, currencyCode: currencyCode, identifier: identifier)
         
         travelInfo = TravelInfo(countryName: countryName, id: id, title: countryName, memo: "updated memo", startDate: startDate, endDate: endDate, coverImage: coverImage, budget: budget, exchangeRate: exchangeRate)
         


### PR DESCRIPTION
### Issue Number
Close #161 

### 변경사항
Country 엔티티에 country identifier 속성을 추가
TravelItemViewModel에 country identifier 속성 추가
BaseHistoryViewModel에 country identifier 속성 추가

### 새로운 기능
지출/예산 상세에서 Currency Symbol을 뽑아 쓸 수 있다.
지출/예산 추가 및 수정 시 amount string을 각 국가에 맞게 formatting 할 수 있다.

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
