### PR TITLE
지출/예산 상세, 추가 및 수정화면에서 카테고리 선택기능 구현

### DIFF
--- a/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
+++ b/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		5CD9A895257DCA2300A7AEFF /* HistoryFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD9A894257DCA2300A7AEFF /* HistoryFilter.swift */; };
 		5CD9A89A257DCD6C00A7AEFF /* HistoryFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD9A899257DCD6C00A7AEFF /* HistoryFilterTests.swift */; };
 		5CF409482575239200351F4B /* MemoEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF409472575239200351F4B /* MemoEditViewController.swift */; };
+		950BE471257F793200ACC0CA /* String+IsCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950BE470257F793200ACC0CA /* String+IsCategory.swift */; };
+		950BE473257F7C7B00ACC0CA /* String+IsPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950BE472257F7C7B00ACC0CA /* String+IsPlaceholder.swift */; };
 		954D2CDD257E2F4800ECE9D9 /* CategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954D2CDB257E2F4800ECE9D9 /* CategoryCollectionViewCell.swift */; };
 		954D2CDE257E2F4800ECE9D9 /* CategoryCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 954D2CDC257E2F4800ECE9D9 /* CategoryCollectionViewCell.xib */; };
 		954F7019256D1C4B00B2E48B /* TravelListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F7018256D1C4B00B2E48B /* TravelListViewModel.swift */; };
@@ -174,6 +176,8 @@
 		5CF409472575239200351F4B /* MemoEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoEditViewController.swift; sourceTree = "<group>"; };
 		81FEEDDEA3FA0D3B4F97EE2F /* Pods_BoostPocketTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BoostPocketTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9381276269F50AEF5C02E72C /* Pods-BoostPocket.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BoostPocket.debug.xcconfig"; path = "Target Support Files/Pods-BoostPocket/Pods-BoostPocket.debug.xcconfig"; sourceTree = "<group>"; };
+		950BE470257F793200ACC0CA /* String+IsCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+IsCategory.swift"; sourceTree = "<group>"; };
+		950BE472257F7C7B00ACC0CA /* String+IsPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+IsPlaceholder.swift"; sourceTree = "<group>"; };
 		954D2CDB257E2F4800ECE9D9 /* CategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		954D2CDC257E2F4800ECE9D9 /* CategoryCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CategoryCollectionViewCell.xib; sourceTree = "<group>"; };
 		954F7018256D1C4B00B2E48B /* TravelListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewModel.swift; sourceTree = "<group>"; };
@@ -517,6 +521,8 @@
 			children = (
 				A9BF7A36256D496C00496CD8 /* String+firstConsonant.swift */,
 				9564EE99257BBE3F00AD85AC /* Character+isOperation.swift */,
+				950BE470257F793200ACC0CA /* String+IsCategory.swift */,
+				950BE472257F7C7B00ACC0CA /* String+IsPlaceholder.swift */,
 				95747A68256FCEEA0065C419 /* Data+ImageData.swift */,
 				A9BF7AA4256F9B8800496CD8 /* Date+ConvertToString.swift */,
 				5CAE96652577FC6300FD7F05 /* Double+Comma.swift */,
@@ -859,9 +865,11 @@
 				A9BF7A71256E2D5900496CD8 /* Travel+CoreDataClass.swift in Sources */,
 				A99E062F257762520014C29F /* History+CoreDataClass.swift in Sources */,
 				5C7F8373257902A100A58112 /* HistoryListSectionHeader.swift in Sources */,
+				950BE471257F793200ACC0CA /* String+IsCategory.swift in Sources */,
 				5C15AB492577DED700244C6C /* HistoryHeaderCell.swift in Sources */,
 				9572F9AE256B9524003049CB /* CountryProvider.swift in Sources */,
 				5CD76EBF256C938D00BD6CE3 /* BoostPocket.xcdatamodeld in Sources */,
+				950BE473257F7C7B00ACC0CA /* String+IsPlaceholder.swift in Sources */,
 				95A42E7A25664DBE0007810C /* AppDelegate.swift in Sources */,
 				5C15AB3E2577C32000244C6C /* HistoryCell.swift in Sources */,
 				5CF409482575239200351F4B /* MemoEditViewController.swift in Sources */,

--- a/BoostPocket/BoostPocket/Extensions/String+IsCategory.swift
+++ b/BoostPocket/BoostPocket/Extensions/String+IsCategory.swift
@@ -1,0 +1,20 @@
+//
+//  String+IsCategory.swift
+//  BoostPocket
+//
+//  Created by sihyung you on 2020/12/08.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func isCategory() -> Bool {
+        var isCategory: Bool = false
+        HistoryCategory.allCases.forEach { category in
+            if self == category.name { isCategory = true }
+        }
+        
+        return isCategory
+    }
+}

--- a/BoostPocket/BoostPocket/Extensions/String+IsPlaceholder.swift
+++ b/BoostPocket/BoostPocket/Extensions/String+IsPlaceholder.swift
@@ -1,0 +1,18 @@
+//
+//  String+IsPlaceholder.swift
+//  BoostPocket
+//
+//  Created by sihyung you on 2020/12/08.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func isPlaceholder() -> Bool {
+        return self == EditMemoType.travelMemo.rawValue
+            || self == EditMemoType.expenseMemo.rawValue
+            || self == EditMemoType.incomeMemo.rawValue
+            || self == "항목명을 입력해주세요 (선택)"
+    }
+}

--- a/BoostPocket/BoostPocket/Models/DataModelInfo.swift
+++ b/BoostPocket/BoostPocket/Models/DataModelInfo.swift
@@ -50,7 +50,7 @@ struct TravelInfo {
     }
 }
 
-enum HistoryCategory: Int16 {
+enum HistoryCategory: Int16, CaseIterable {
     case income = 0
     case food
     case shopping

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -156,7 +156,6 @@ class AddHistoryViewController: UIViewController {
         }
         
         // 날짜
-        // TODO: DatePicker로 변경해서 사용자가 날짜를 바꿀 수 있도록 하는 기능 구현하기
         datePicker.setDate(newHistoryViewModel.currentDate, animated: true)
         
         // 이미지
@@ -355,8 +354,16 @@ extension AddHistoryViewController: UICollectionViewDataSource, UICollectionView
             return UICollectionViewCell()
         }
         
-        cell.configure(with: categories[indexPath.row])
+        let isSelected = categories[indexPath.row] == self.category
+        cell.configure(with: categories[indexPath.row], isSelected: isSelected)
+
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.category = categories[indexPath.row]
+        collectionView.reloadData()
+        
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -54,13 +54,10 @@ class AddHistoryViewController: UIViewController {
     private var saveButtonHandler: (() -> Void)?
     private var baseHistoryViewModel: BaseHistoryViewModel?
     private var isAddingIncome: Bool = false
-    private var historyTitle: String?
     private var memo: String?
-    private var date: Date = Date()
     private var image: Data?
     private var amount: Double = 0
     private var category: HistoryCategory = .etc
-    private var isCard: Bool = false
     private var imagePicker = UIImagePickerController()
     private let historyTitlePlaceholder = "항목명을 입력해주세요 (선택)"
     private var categories: [HistoryCategory] = [.food, .shopping, .tourism, .transportation, .accommodation, .etc]
@@ -90,7 +87,9 @@ class AddHistoryViewController: UIViewController {
     
     private func configureViews() {
         guard let baseHistoryViewModel = self.baseHistoryViewModel else { return }
+        
         self.isAddingIncome = baseHistoryViewModel.isIncome
+        
         if let _ = baseHistoryViewModel.id {
             self.isCreate = false
         }
@@ -131,7 +130,6 @@ class AddHistoryViewController: UIViewController {
         // 카드/현금 여부
         if let previousIsCard = baseHistoryViewModel.isCard, previousIsCard {
             segmentedControl.selectedSegmentIndex = 1
-            self.isCard = true
         } else {
             segmentedControl.selectedSegmentIndex = 0
         }
@@ -148,8 +146,7 @@ class AddHistoryViewController: UIViewController {
         let titleTap = UITapGestureRecognizer(target: self, action: #selector(titleLabelTapped))
         historyTitleLabel.addGestureRecognizer(titleTap)
         if let previousTitle = baseHistoryViewModel.title {
-            self.historyTitle = previousTitle
-            historyTitleLabel.text = self.historyTitle
+            historyTitleLabel.text = previousTitle
             historyTitleLabel.textColor = .black
         } else {
             historyTitleLabel.text = historyTitlePlaceholder
@@ -208,30 +205,18 @@ class AddHistoryViewController: UIViewController {
         return true
     }
     
-    @IBAction func segmentDidChange(_ sender: UISegmentedControl) {
-        switch sender.selectedSegmentIndex {
-        case 0:
-            self.isCard = false
-        case 1:
-            self.isCard = true
-        default:
-            break
-        }
-    }
-    
     @objc func titleLabelTapped() {
-        let previousTitle = historyTitleLabel.text == historyTitlePlaceholder ? "" : historyTitle
+        let previousTitle = historyTitleLabel.text == historyTitlePlaceholder ? "" : historyTitleLabel.text
         
         TitleEditViewController.present(at: self, previousTitle: previousTitle ?? "") { [weak self] (newTitle) in
             guard let self = self else { return }
             if self.isAddingIncome {
-                self.historyTitle = newTitle.isEmpty ? HistoryCategory.income.name : newTitle
+                self.historyTitleLabel.text = newTitle.isEmpty ? HistoryCategory.income.name : newTitle
             } else {
-                self.historyTitle = newTitle.isEmpty ? HistoryCategory.etc.name : newTitle
+                self.historyTitleLabel.text = newTitle.isEmpty ? HistoryCategory.etc.name : newTitle
             }
             
-            self.historyTitleLabel.textColor = self.historyTitle == self.historyTitlePlaceholder ? .systemGray2 : .black
-            self.historyTitleLabel.text = self.historyTitle
+            self.historyTitleLabel.textColor = self.historyTitleLabel.text == self.historyTitlePlaceholder ? .systemGray2 : .black
         }
     }
     
@@ -243,9 +228,9 @@ class AddHistoryViewController: UIViewController {
         var newHistoryData: NewHistoryData
         
         if isAddingIncome {
-            newHistoryData = NewHistoryData(isIncome: true, title: historyTitle ?? HistoryCategory.income.name, memo: memo, date: datePicker.date, image: nil, amount: amount, category: .income, isCard: nil)
+            newHistoryData = NewHistoryData(isIncome: true, title: historyTitleLabel.text ?? HistoryCategory.income.name, memo: memo, date: datePicker.date, image: nil, amount: amount, category: .income, isCard: nil)
         } else {
-            newHistoryData = NewHistoryData(isIncome: false, title: historyTitle ?? HistoryCategory.etc.name, memo: memo, date: datePicker.date, image: image, amount: amount, category: category, isCard: isCard, isPrepare: baseHistoryViewModel?.isPrepare)
+            newHistoryData = NewHistoryData(isIncome: false, title: historyTitleLabel.text ?? HistoryCategory.etc.name, memo: memo, date: datePicker.date, image: image, amount: amount, category: category, isCard: segmentedControl.selectedSegmentIndex == 0 ? false : true, isPrepare: baseHistoryViewModel?.isPrepare)
         }
         
         if isCreate {

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -227,10 +227,32 @@ class AddHistoryViewController: UIViewController {
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         var newHistoryData: NewHistoryData
         
-        if isAddingIncome {
-            newHistoryData = NewHistoryData(isIncome: true, title: historyTitleLabel.text ?? HistoryCategory.income.name, memo: memo, date: datePicker.date, image: nil, amount: amount, category: .income, isCard: nil)
+        var defaultTitle: String
+        if let titleLabelText = historyTitleLabel.text {
+            defaultTitle = titleLabelText.isPlaceholder() ? category.name : titleLabelText
         } else {
-            newHistoryData = NewHistoryData(isIncome: false, title: historyTitleLabel.text ?? HistoryCategory.etc.name, memo: memo, date: datePicker.date, image: image, amount: amount, category: category, isCard: segmentedControl.selectedSegmentIndex == 0 ? false : true, isPrepare: baseHistoryViewModel?.isPrepare)
+            defaultTitle = category.name
+        }
+        
+        if isAddingIncome {
+            newHistoryData = NewHistoryData(isIncome: true,
+                                            title: defaultTitle.isCategory() ? HistoryCategory.income.name : defaultTitle ,
+                                            memo: memo,
+                                            date: datePicker.date,
+                                            image: nil,
+                                            amount: amount,
+                                            category: .income,
+                                            isCard: nil)
+        } else {
+            
+            newHistoryData = NewHistoryData(isIncome: false,
+                                            title: defaultTitle.isCategory() ? category.name : defaultTitle,
+                                            memo: memo,
+                                            date: datePicker.date,
+                                            image: image,
+                                            amount: amount,
+                                            category: category,
+                                            isCard: segmentedControl.selectedSegmentIndex == 0 ? false : true, isPrepare: baseHistoryViewModel?.isPrepare)
         }
         
         if isCreate {
@@ -340,14 +362,13 @@ extension AddHistoryViewController: UICollectionViewDataSource, UICollectionView
             return UICollectionViewCell()
         }
         
-        let isSelected = categories[indexPath.row] == self.category
-        cell.configure(with: categories[indexPath.row], isSelected: isSelected)
+        cell.configure(with: categories[indexPath.row], isSelected: categories[indexPath.row] == self.category)
 
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.category = categories[indexPath.row]
+        category = categories[indexPath.row]
         collectionView.reloadData()
         
     }

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.swift
@@ -89,9 +89,9 @@ class AddHistoryViewController: UIViewController {
     }
     
     private func configureViews() {
-        guard let newHistoryViewModel = self.baseHistoryViewModel else { return }
-        self.isAddingIncome = newHistoryViewModel.isIncome
-        if let _ = newHistoryViewModel.id {
+        guard let baseHistoryViewModel = self.baseHistoryViewModel else { return }
+        self.isAddingIncome = baseHistoryViewModel.isIncome
+        if let _ = baseHistoryViewModel.id {
             self.isCreate = false
         }
         
@@ -110,18 +110,18 @@ class AddHistoryViewController: UIViewController {
         historyTypeLabel.textColor = .white
         
         // 국기 이미지
-        flagImageView.image = UIImage(data: newHistoryViewModel.flagImage)
+        flagImageView.image = UIImage(data: baseHistoryViewModel.flagImage)
         
         // 환율코드
-        currencyCodeLabel.text = newHistoryViewModel.currencyCode
+        currencyCodeLabel.text = baseHistoryViewModel.currencyCode
         
         // 계산식 레이블, 계산된 금액 레이블, 환율을 적용하여 변환한 금액 레이블
         calculatedAmountLabel.textColor = .white
-        if let previousAmount = newHistoryViewModel.amount {
+        if let previousAmount = baseHistoryViewModel.amount {
             self.amount = previousAmount
             calculatorExpressionLabel.text = "\(previousAmount)"
             calculatedAmountLabel.text = "\(previousAmount)"
-            currencyConvertedAmountLabel.text = "KRW \((previousAmount / newHistoryViewModel.exchangeRate).getCurrencyFormat(identifier: baseHistoryViewModel?.countryIdentifier ?? ""))"
+            currencyConvertedAmountLabel.text = "KRW \((previousAmount / baseHistoryViewModel.exchangeRate).getCurrencyFormat(identifier: baseHistoryViewModel.countryIdentifier ?? ""))"
         } else {
             calculatorExpressionLabel.text = ""
             calculatedAmountLabel.text = "0"
@@ -129,7 +129,7 @@ class AddHistoryViewController: UIViewController {
         }
         
         // 카드/현금 여부
-        if let previousIsCard = newHistoryViewModel.isCard, previousIsCard {
+        if let previousIsCard = baseHistoryViewModel.isCard, previousIsCard {
             segmentedControl.selectedSegmentIndex = 1
             self.isCard = true
         } else {
@@ -141,12 +141,13 @@ class AddHistoryViewController: UIViewController {
             categoryCollectionView.delegate = self
             categoryCollectionView.dataSource = self
             categoryCollectionView.register(UINib(nibName: CategoryCollectionViewCell.identifier, bundle: nil), forCellWithReuseIdentifier: CategoryCollectionViewCell.identifier)
+            self.category = baseHistoryViewModel.category ?? .etc
         }
         
         // 항목명
         let titleTap = UITapGestureRecognizer(target: self, action: #selector(titleLabelTapped))
         historyTitleLabel.addGestureRecognizer(titleTap)
-        if let previousTitle = newHistoryViewModel.title {
+        if let previousTitle = baseHistoryViewModel.title {
             self.historyTitle = previousTitle
             historyTitleLabel.text = self.historyTitle
             historyTitleLabel.textColor = .black
@@ -156,16 +157,16 @@ class AddHistoryViewController: UIViewController {
         }
         
         // 날짜
-        datePicker.setDate(newHistoryViewModel.currentDate, animated: true)
+        datePicker.setDate(baseHistoryViewModel.currentDate, animated: true)
         
         // 이미지
-        if let previousImage = newHistoryViewModel.image {
+        if let previousImage = baseHistoryViewModel.image {
             self.image = previousImage
             self.imageButton.tintColor = .black
         }
         
         // 메모
-        if let previousMemo = newHistoryViewModel.memo {
+        if let previousMemo = baseHistoryViewModel.memo {
             self.memo = previousMemo
             self.memoButton.tintColor = .black
         }

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.xib
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryViewController.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -42,7 +40,7 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="158"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지출/수입" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X8B-Q2-jmd" customClass="PaddedLabel" customModule="BoostPocket" customModuleProvider="target">
-                            <rect key="frame" x="182.5" y="10" width="49" height="16"/>
+                            <rect key="frame" x="182.5" y="10" width="49.5" height="16"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -62,7 +60,7 @@
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tkA-TC-4Rx" userLabel="Expression">
-                            <rect key="frame" x="154.5" y="31" width="249.5" height="20.5"/>
+                            <rect key="frame" x="155" y="31" width="249" height="20.5"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="wt4-sK-9dJ"/>
                             </constraints>
@@ -71,19 +69,19 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aLb-EL-GfB" userLabel="Currency Converted">
-                            <rect key="frame" x="154.5" y="107.5" width="249.5" height="40.5"/>
+                            <rect key="frame" x="155" y="107.5" width="249" height="40.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qEf-JD-335" userLabel="Currency Code">
-                            <rect key="frame" x="103" y="69.5" width="41.5" height="20.5"/>
+                            <rect key="frame" x="103" y="69.5" width="42" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="20" translatesAutoresizingMaskIntoConstraints="NO" id="4pe-9q-UpJ" userLabel="Amount">
-                            <rect key="frame" x="154.5" y="61.5" width="249.5" height="36"/>
+                            <rect key="frame" x="155" y="61.5" width="249" height="36"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -94,9 +92,6 @@
                                 <segment title="현금"/>
                                 <segment title="카드"/>
                             </segments>
-                            <connections>
-                                <action selector="segmentDidChange:" destination="-1" eventType="valueChanged" id="Qf4-O2-cFF"/>
-                            </connections>
                         </segmentedControl>
                     </subviews>
                     <constraints>
@@ -131,7 +126,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="zNC-ne-17w" userLabel="Line 1">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="78.5"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pnc-fS-OM8">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pnc-fS-OM8">
                                     <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="1">
@@ -141,7 +136,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="U5M-Pv-OdA"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="blA-Xr-rfk">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="blA-Xr-rfk">
                                     <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="2">
@@ -151,7 +146,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="nDh-so-2N8"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o0M-UP-Rk5">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o0M-UP-Rk5">
                                     <rect key="frame" x="207" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="3">
@@ -161,7 +156,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="uU4-PZ-XuC"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yad-QF-DSb">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yad-QF-DSb">
                                     <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="/">
@@ -176,7 +171,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="TVS-ym-BML" userLabel="Line 2">
                             <rect key="frame" x="0.0" y="78.5" width="414" height="78"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L5d-QI-dZG">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L5d-QI-dZG">
                                     <rect key="frame" x="0.0" y="0.0" width="103.5" height="78"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="4">
@@ -186,7 +181,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="v2S-OL-bKc"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uqZ-Zx-Nzq">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uqZ-Zx-Nzq">
                                     <rect key="frame" x="103.5" y="0.0" width="103.5" height="78"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="5">
@@ -196,7 +191,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="OwG-6A-30c"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TEQ-Wv-51m">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TEQ-Wv-51m">
                                     <rect key="frame" x="207" y="0.0" width="103.5" height="78"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="6">
@@ -206,7 +201,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="n0L-7g-9nc"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpW-m6-gJK">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpW-m6-gJK">
                                     <rect key="frame" x="310.5" y="0.0" width="103.5" height="78"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="*">
@@ -221,7 +216,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="mTC-rY-0q7" userLabel="Line 3">
                             <rect key="frame" x="0.0" y="156.5" width="414" height="78.5"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eb0-or-e7a">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eb0-or-e7a">
                                     <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="7">
@@ -231,7 +226,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="6qK-ZD-ZHw"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vDc-72-ZGQ">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vDc-72-ZGQ">
                                     <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="8">
@@ -241,7 +236,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="uq3-yZ-VsB"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dO6-ES-U6p">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dO6-ES-U6p">
                                     <rect key="frame" x="207" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="9">
@@ -251,7 +246,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="Drk-Pm-02K"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gMU-9A-ueg">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gMU-9A-ueg">
                                     <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="+">
@@ -266,7 +261,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="USD-XQ-8mw" userLabel="Line 4">
                             <rect key="frame" x="0.0" y="235" width="414" height="78.5"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="59c-I8-mls">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="59c-I8-mls">
                                     <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title=".">
@@ -276,7 +271,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="g1B-hj-p7H"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZL6-uO-xEa">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZL6-uO-xEa">
                                     <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="0">
@@ -297,7 +292,7 @@
                                         <action selector="backTapped:" destination="-1" eventType="touchUpInside" id="Grj-Zy-igZ"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hcc-d6-yrA">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hcc-d6-yrA">
                                     <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="-">
@@ -314,7 +309,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="Uvo-Ni-ty9" userLabel="Line 0">
                     <rect key="frame" x="0.0" y="503.5" width="414" height="45"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Ea-lC-YV1">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Ea-lC-YV1">
                             <rect key="frame" x="0.0" y="0.0" width="52" height="45"/>
                             <state key="normal" title="취소"/>
                             <connections>
@@ -327,7 +322,7 @@
                         </datePicker>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5UH-g4-mMe" userLabel="Picture">
                             <rect key="frame" x="298.5" y="0.0" width="32" height="45"/>
-                            <color key="tintColor" systemColor="systemGray3Color"/>
+                            <color key="tintColor" systemColor="systemGray3Color" red="0.78039215689999997" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <state key="normal" image="photo" catalog="system"/>
                             <connections>
                                 <action selector="addImageButtonTapped:" destination="-1" eventType="touchUpInside" id="LG4-Eq-Ho1"/>
@@ -335,13 +330,13 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14w-LZ-14y" userLabel="Memo">
                             <rect key="frame" x="330.5" y="0.0" width="32" height="45"/>
-                            <color key="tintColor" systemColor="systemGray3Color"/>
+                            <color key="tintColor" systemColor="systemGray3Color" red="0.78039215689999997" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <state key="normal" image="list.dash" catalog="system"/>
                             <connections>
                                 <action selector="addMemoButtonTapped:" destination="-1" eventType="touchUpInside" id="c6o-T4-531"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-oJ-N8p">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-oJ-N8p">
                             <rect key="frame" x="362.5" y="0.0" width="51.5" height="45"/>
                             <state key="normal" title="저장"/>
                             <connections>
@@ -364,14 +359,14 @@
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lci-Ei-eGZ" userLabel="Divider">
                     <rect key="frame" x="62" y="477.5" width="290" height="1"/>
-                    <color key="backgroundColor" systemColor="systemGray2Color"/>
+                    <color key="backgroundColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="a2a-5Y-BCG"/>
                     </constraints>
                 </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="heQ-Ap-lf8">
                     <rect key="frame" x="0.0" y="212" width="414" height="255.5"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="V01-ce-Dyy">
                         <size key="itemSize" width="128" height="128"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -380,8 +375,7 @@
                     </collectionViewFlowLayout>
                 </collectionView>
             </subviews>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
                 <constraint firstItem="lci-Ei-eGZ" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="4iX-Zc-Elj"/>
                 <constraint firstItem="0kX-Kl-MDd" firstAttribute="top" secondItem="Uvo-Ni-ty9" secondAttribute="bottom" id="5dm-zO-9oG"/>
@@ -405,6 +399,7 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="0kX-Kl-MDd" secondAttribute="trailing" id="yGV-oI-Eax"/>
                 <constraint firstItem="RY6-19-kNJ" firstAttribute="top" secondItem="lci-Ei-eGZ" secondAttribute="bottom" constant="10" id="zB8-II-ahG"/>
             </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="131.8840579710145" y="150.66964285714286"/>
         </view>
     </objects>
@@ -412,14 +407,5 @@
         <image name="list.dash" catalog="system" width="128" height="85"/>
         <image name="photo" catalog="system" width="128" height="93"/>
         <image name="return" catalog="system" width="128" height="101"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray2Color">
-            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemGray3Color">
-            <color red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
     </resources>
 </document>

--- a/BoostPocket/BoostPocket/TravelDetailScene/CategoryCollectionViewCell.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/CategoryCollectionViewCell.swift
@@ -15,9 +15,10 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var categoryImage: UIImageView!
     @IBOutlet weak var categoryNameLabel: UILabel!
     
-    func configure(with category: HistoryCategory) {
+    func configure(with category: HistoryCategory, isSelected: Bool) {
         self.categoryImage.image = UIImage(named: category.imageName)
         self.categoryNameLabel.text = category.name
+        self.isSelected = isSelected
     }
     
     override var isSelected: Bool {

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailViewController.swift
@@ -189,11 +189,14 @@ class HistoryDetailViewController: UIViewController {
     }
     
     @objc func titleLabelTapped() {
-        let previousTitle = titleLabel.text
+        var defaultTitle = ""
+        if let baseHistoryViewModel = baseHistoryViewModel {
+            defaultTitle = baseHistoryViewModel.isIncome ? "예산 금액 추가" : baseHistoryViewModel.category?.name ?? HistoryCategory.etc.name
+        }
         
-        TitleEditViewController.present(at: self, previousTitle: previousTitle ?? "") { [weak self] (newTitle) in
+        TitleEditViewController.present(at: self, previousTitle: titleLabel.text ?? "") { [weak self] (newTitle) in
             guard let self = self else { return }
-            let updatingTitle = newTitle.isEmpty ? previousTitle : newTitle
+            let updatingTitle = newTitle.isEmpty ? defaultTitle : newTitle
             self.titleLabel.text = updatingTitle
             self.baseHistoryViewModel?.title = updatingTitle
             self.updateHistory()

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailViewController.swift
@@ -176,6 +176,9 @@ class HistoryDetailViewController: UIViewController {
             } else {
                 self.expenseMemoLabel.text = historyItemViewModel.memo ?? EditMemoType.expenseMemo.rawValue
             }
+            
+            // isCard
+            self.baseHistoryViewModel?.isCard = historyItemViewModel.isCard
         }
         
         AddHistoryViewController.present(at: self,

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailViewController.swift
@@ -156,6 +156,8 @@ class HistoryDetailViewController: UIViewController {
             self.exchangedMoneyLabel.text = "KRW \((historyItemViewModel.amount / baseHistoryViewModel.exchangeRate).getCurrencyFormat(identifier: countryIdentifier))"
             
             // category도 해줘야 함
+            self.baseHistoryViewModel?.category = historyItemViewModel.category
+            self.categoryImageView.image = UIImage(named: historyItemViewModel.category.imageName)
             
             // title
             self.baseHistoryViewModel?.title = self.historyItemViewModel?.title

--- a/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/MemoEditViewController.swift
@@ -134,11 +134,3 @@ extension MemoEditViewController {
         })
     }
 }
-
-extension String {
-    func isPlaceholder() -> Bool {
-        return self == EditMemoType.travelMemo.rawValue
-            || self == EditMemoType.expenseMemo.rawValue
-            || self == EditMemoType.incomeMemo.rawValue
-    }
-}


### PR DESCRIPTION
### Issue Number
Close #169 

### 변경사항
- 지출/예산 추가 및 수정화면에서 collectionView의 cell이 현재 선택된 category와 동일하다면 선택된 표시하도록 구현
- reloadData를 사용함으로써 다른 cell을 선택했을 때 해당 변경내용이 뷰에도 반영되도록 구현
- 지출/예산 상세화면에서 카드, 현금 변경사항이 baseHistoryViewModel에 적용되지 않았던 점 수정
- 지출/예산 상세화면에서 카테고리 이미지 변경사항 반영하도록 구현

### 새로운 기능
- 지출을 생성 및 수정할 때 카테고리를 선택할 수 있다.

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
