### PR TITLE
TravelListViewContoller DiffableDataSource에서 reloadData 제거

### DIFF
--- a/BoostPocket/BoostPocket/Constants/Sections.swift
+++ b/BoostPocket/BoostPocket/Constants/Sections.swift
@@ -8,7 +8,12 @@
 
 import Foundation
 
-enum TravelSection {
+struct TravelSection: Hashable {
+    var travelSectionCase: TravelSectionCase
+    var numberOfTravels: Int
+}
+
+enum TravelSectionCase {
     case current
     case upcoming
     case past

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.swift
@@ -369,12 +369,13 @@ extension AddHistoryViewController: UICollectionViewDataSource, UICollectionView
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = categoryCollectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as? CategoryCollectionViewCell else {
-            return UICollectionViewCell()
-        }
+        guard let cell = categoryCollectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier,
+                                                                    for: indexPath) as? CategoryCollectionViewCell
+            else {
+                return UICollectionViewCell()
+            }
         
         cell.configure(with: categories[indexPath.row], isSelected: categories[indexPath.row] == self.category)
-
         return cell
     }
     

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/HistoryListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/HistoryListViewController.swift
@@ -64,7 +64,6 @@ class HistoryListViewController: UIViewController {
     private func configure() {
         allButton.configureSelectedButton()
         configureTravelItemViewModel()
-        self.historyListTableView.dataSource = self.dataSource
         configureTableView()
         configureSegmentedControl()
         configureFloatingActionButton()
@@ -81,6 +80,7 @@ class HistoryListViewController: UIViewController {
     
     private func configureTableView() {
         historyListTableView.delegate = self
+        historyListTableView.dataSource = dataSource
         historyListTableView.register(HistoryCell.getNib(), forCellReuseIdentifier: HistoryCell.identifier)
         historyListTableView.register(HistoryHeaderCell.getNib(), forHeaderFooterViewReuseIdentifier: HistoryHeaderCell.identifier)
     }

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelCell.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelCell.swift
@@ -19,14 +19,19 @@ class TravelCell: UICollectionViewCell {
     @IBOutlet weak var spentMoneyLabel: UILabel!
     
     func configure(with travel: TravelItemViewModel) {
-        guard let coverImage = travel.coverImage, let flagImage = travel.flagImage else { return }
+        guard let coverImage = travel.coverImage,
+            let flagImage = travel.flagImage,
+            let identifier = travel.countryIdentifier
+            else { return }
         
         travelTitleLabel.text = travel.title
         configureCoverImage(coverImage: coverImage)
         configureDate(startDate: travel.startDate, endDate: travel.endDate)
         flagImageView.image = UIImage(data: flagImage)
-        // TODO : 총 사용 금액으로 설정하기
-        spentMoneyLabel.text = "₩ \(Int(travel.budget))"
+        
+        let totalExpenseKRW = travel.getTotalExpense() / travel.exchangeRate
+        let totalExpenseKRWString = totalExpenseKRW.getCurrencyFormat(identifier: identifier)
+        spentMoneyLabel.text = "₩ " + totalExpenseKRWString
     }
     
     private func configureCoverImage(coverImage: Data) {

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelCell.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelCell.swift
@@ -19,10 +19,7 @@ class TravelCell: UICollectionViewCell {
     @IBOutlet weak var spentMoneyLabel: UILabel!
     
     func configure(with travel: TravelItemViewModel) {
-        guard let coverImage = travel.coverImage,
-            let flagImage = travel.flagImage,
-            let identifier = travel.countryIdentifier
-            else { return }
+        guard let coverImage = travel.coverImage, let flagImage = travel.flagImage else { return }
         
         travelTitleLabel.text = travel.title
         configureCoverImage(coverImage: coverImage)
@@ -30,7 +27,7 @@ class TravelCell: UICollectionViewCell {
         flagImageView.image = UIImage(data: flagImage)
         
         let totalExpenseKRW = travel.getTotalExpense() / travel.exchangeRate
-        let totalExpenseKRWString = totalExpenseKRW.getCurrencyFormat(identifier: identifier)
+        let totalExpenseKRWString = totalExpenseKRW.getCurrencyFormat(identifier: "ko_KR")
         spentMoneyLabel.text = "₩ " + totalExpenseKRWString
     }
     

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelHeaderCell.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelHeaderCell.swift
@@ -9,26 +9,29 @@
 import UIKit
 
 class TravelHeaderCell: UICollectionReusableView {
-    
     static let identifier = "TravelHeaderCell"
+    
     @IBOutlet weak var headerLabel: UILabel!
     
-    override func awakeFromNib() {
-        super.awakeFromNib()
-    }
-    
-    func configure(with sectionType: TravelSection, numberOfTravel: Int = 0) {
+    func configure(with sectionType: TravelSectionCase, numberOfTravel: Int = 0) {
         switch sectionType {
         case .current:
-            let message = "지금까지 \(numberOfTravel)개 나라를 여행 했습니다"
-            let attributedString = NSMutableAttributedString(string: message)
-            attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor(named: "mainColor") ?? UIColor.systemBlue, range: (message as NSString).range(of: "\(numberOfTravel)"))
+            let attributedString = getAttributedString(of: "지금까지 \(numberOfTravel)개 나라를 여행 했습니다", numberOfTravel: numberOfTravel)
             headerLabel.attributedText = attributedString
         case .past:
-            headerLabel.text = "지난 여행"
+            let attributedString = getAttributedString(of: "지난 여행 \(numberOfTravel)개", numberOfTravel: numberOfTravel)
+            headerLabel.attributedText = attributedString
         case .upcoming:
-            headerLabel.text = "다가오는 여행"
+            let attributedString = getAttributedString(of: "다가오는 여행 \(numberOfTravel)개", numberOfTravel: numberOfTravel)
+            headerLabel.attributedText = attributedString
         }
+    }
+    
+    private func getAttributedString(of message: String, numberOfTravel: Int) -> NSMutableAttributedString {
+        let attributedString = NSMutableAttributedString(string: message)
+        attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor(named: "mainColor") ?? UIColor.systemBlue, range: (message as NSString).range(of: "\(numberOfTravel)"))
+        
+        return attributedString
     }
     
     /*

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
@@ -29,10 +29,6 @@ class TravelListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureCollectionView()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         travelListViewModel?.needFetchItems()
         travelListViewModel?.didFetch = { [weak self] fetchedTravels in
             self?.applySnapShot(with: fetchedTravels)


### PR DESCRIPTION
### Issue Number
Close #197 

### 변경사항
- Diffable DataSorce의 제대로 된 활용을 위해 reloadData 제거
- reloadData를 제거하면서 동시에 데이터 업데이트를 반영하여 headerCell을 configure
  하기위해 Section의 형태에 진행중/과거/미래의 여행 개수를 포함해야 함
- 따라서 TravelSection이라는 구조체를 선언했으며 해당 구조체는 과거/현재/미래를
  표현하는 데이터 TravelSection, 그리고 자신에게 포함된 여행의 개수 Int를 가짐
- applysnapshot은 데이터가 업데이트되었을 때 반드시 불리는 함수이므로 이 함수에서
  각 섹션의 여행 개수를 새로 계산하여 appendSections, appendItems를 통해 새로운
  스냅샷을 생성하고 apply
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/35067611/101667411-a9014100-3a92-11eb-8d24-463fc3b0821f.gif)
결과 : reloadData() 없이도 올바르게 변경된 여행 개수 정보를 헤더에 적용할 수 있음

- 지난여행과 다가오는여행의 header cell에도 여행개수를 표시함
![image](https://user-images.githubusercontent.com/35067611/101667771-14e3a980-3a93-11eb-973a-e27c75b6b9b0.png)

- TravelCell에서 지출의 합을 표시하도록 변경
![image](https://user-images.githubusercontent.com/35067611/101667728-072e2400-3a93-11eb-92c7-3a7a4cdc2836.png)


### 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
