### PR TITLE
다크모드 지원

### DIFF
--- a/BoostPocket/BoostPocket/Assets.xcassets/colors/lightMainColor.colorset/Contents.json
+++ b/BoostPocket/BoostPocket/Assets.xcassets/colors/lightMainColor.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.986",
+          "green" : "0.907",
+          "red" : "0.866"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/DayCell.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/DayCell.swift
@@ -40,7 +40,7 @@ class DayCell: UIView {
     
     private func configureDayButton(with date: Date) {
         dayButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
-        dayButton.setTitleColor(.black, for: .normal)
+        dayButton.setTitleColor(UIColor(named: "basicBlackTextColor"), for: .normal)
         guard let dayInt = Int(date.convertToString(format: .day)) else { return }
         dayButton.setTitle(String(dayInt), for: .normal)
     }
@@ -82,6 +82,6 @@ extension UIButton {
     
     func configureDeselectedButton() {
         self.backgroundColor = .clear
-        self.setTitleColor(.black, for: .normal)
+        self.setTitleColor(UIColor(named: "basicBlackTextColor"), for: .normal)
     }
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/TotalAmountView.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/TotalAmountView.swift
@@ -29,6 +29,7 @@ class TotalAmountView: UIView {
             remainLabel.textColor = remain < 0 ? UIColor(named: "deleteTextColor") : UIColor(named: "detailIncomeColor")
         }
         expenseLabel.text = setLabel(with: identifier, amount: expense)
+        expenseLabel.textColor = .black
 
     }
     


### PR DESCRIPTION
### Issue Number
Close #183

### 변경사항
- 다크모드 시, 적용되지 않던 일부 텍스트 색상들을 다크모드가 지원되도록
  색상 변경
-> day cell의 날짜 색상 및 하단 총 금액에 대한 텍스트 색상

### 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
