### PR TITLE
지출이 없을 때 리포트화면 구조 변경

### DIFF
--- a/BoostPocket/BoostPocket/TravelDetailScene/ReportScene/ExpenseElementView.xib
+++ b/BoostPocket/BoostPocket/TravelDetailScene/ReportScene/ExpenseElementView.xib
@@ -32,13 +32,13 @@
                         <constraint firstItem="j8M-oO-yJS" firstAttribute="centerY" secondItem="qdl-aO-fij" secondAttribute="centerY" id="m6D-Pk-Suy"/>
                     </constraints>
                 </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dC8-lu-fAp" userLabel="Category Name">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dC8-lu-fAp" userLabel="Category Name">
                     <rect key="frame" x="131" y="69" width="42" height="20.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BIZ-oe-WiS" userLabel="Currency Code">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BIZ-oe-WiS" userLabel="Currency Code">
                     <rect key="frame" x="131" y="137.5" width="42" height="20.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" name="basicGrayTextColor"/>

--- a/BoostPocket/BoostPocket/TravelDetailScene/ReportScene/ReportViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/ReportScene/ReportViewController.swift
@@ -19,6 +19,7 @@ class ReportViewController: UIViewController {
     @IBOutlet weak var currencyCodeLabel: UILabel!
     @IBOutlet weak var totalExpenseLabel: UILabel!
     @IBOutlet weak var expensesStackView: UIStackView!
+    @IBOutlet weak var informationView: UIView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,7 +30,6 @@ class ReportViewController: UIViewController {
         reportPieChartView.slices = setupSlices()
         reportPieChartView.animateChart()
         configureLabels()
-
     }
     
     override func viewWillLayoutSubviews() {
@@ -47,21 +47,31 @@ class ReportViewController: UIViewController {
         
         totalExpenseKRWLabel.text = "KRW ₩ \(totalAmountKRW.getCurrencyFormat(identifier: "ko_KR"))"
         totalExpenseLabel.text = identifier.currencySymbol + " " + totalAmount.getCurrencyFormat(identifier: identifier)
-        let mostFrequentItem = travelItemViewModel.mostFrequentCategory
-        let categoryString = mostFrequentItem.0.name
-        let percentageString = String(format: "%.1f%%", mostFrequentItem.1)
-        let message = categoryString + "에 가장 많은 소비를 했습니다.\n총 지출 금액의 " + percentageString + "를 차지합니다"
         
-        let attributedString = NSMutableAttributedString(string: message)
-        let fontSize = UIFont.boldSystemFont(ofSize: 25)
-        attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor(named: mostFrequentItem.0.imageName + "-color") ?? UIColor.systemBlue, range: (message as NSString).range(of: categoryString))
-        
-        attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor(named: "mainColor") ?? UIColor.systemBlue, range: (message as NSString).range(of: percentageString))
-        
-        attributedString.addAttribute(NSAttributedString.Key(rawValue: kCTFontAttributeName as String), value: fontSize, range: (message as NSString).range(of: categoryString))
-        attributedString.addAttribute(NSAttributedString.Key(rawValue: kCTFontAttributeName as String), value: fontSize, range: (message as NSString).range(of: percentageString))
-        
-        summaryLabel.attributedText = attributedString
+        if totalAmount > 0 {
+            informationView.isHidden = false
+            reportPieChartView.isHidden = false
+            
+            let mostFrequentItem = travelItemViewModel.mostFrequentCategory
+            let categoryString = mostFrequentItem.0.name
+            let percentageString = String(format: "%.1f%%", mostFrequentItem.1)
+            let message = categoryString + "에 가장 많은 소비를 했습니다.\n총 지출 금액의 " + percentageString + "를 차지합니다"
+            let attributedString = NSMutableAttributedString(string: message)
+            let fontSize = UIFont.boldSystemFont(ofSize: 25)
+            
+            attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor(named: mostFrequentItem.0.imageName + "-color") ?? UIColor.systemBlue, range: (message as NSString).range(of: categoryString))
+            
+            attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor(named: "mainColor") ?? UIColor.systemBlue, range: (message as NSString).range(of: percentageString))
+            
+            attributedString.addAttribute(NSAttributedString.Key(rawValue: kCTFontAttributeName as String), value: fontSize, range: (message as NSString).range(of: categoryString))
+            attributedString.addAttribute(NSAttributedString.Key(rawValue: kCTFontAttributeName as String), value: fontSize, range: (message as NSString).range(of: percentageString))
+            
+            summaryLabel.attributedText = attributedString
+        } else {
+            summaryLabel.text = "지출 내역이 없습니다."
+            informationView.isHidden = true
+            reportPieChartView.isHidden = true
+        }
     }
     
     private func configureStackView() {

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,7 +19,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ALI-AJ-0ck" userLabel="Divider">
                                 <rect key="frame" x="118.5" y="50" width="0.0" height="47"/>
-                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="0.29999999999999999" id="jZE-uh-4VG"/>
                                 </constraints>
@@ -58,7 +56,7 @@
                                         </constraints>
                                     </scrollView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="NrH-bA-9YK" secondAttribute="bottom" id="BeG-kR-7Bc"/>
                                     <constraint firstItem="jFB-Ve-ziB" firstAttribute="height" secondItem="Z3N-xh-feq" secondAttribute="height" id="Uxo-A3-1Jj"/>
@@ -79,21 +77,21 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4RM-9s-J1O">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4RM-9s-J1O">
                                                 <rect key="frame" x="15" y="7" width="29.5" height="29.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="4RM-9s-J1O" secondAttribute="height" multiplier="1:1" id="y2f-Gy-RwD"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <state key="normal" title="A">
-                                                    <color key="titleColor" systemColor="labelColor"/>
+                                                    <color key="titleColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                                 </state>
                                                 <connections>
                                                     <action selector="isPrepareButtonTapped:" destination="fmi-ND-nuS" eventType="touchUpInside" id="0Xs-Hi-ViN"/>
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstItem="4RM-9s-J1O" firstAttribute="width" secondItem="Nhk-Y4-RcI" secondAttribute="width" multiplier="0.5" id="AqU-4x-YGi"/>
                                             <constraint firstItem="PJt-Ce-JhI" firstAttribute="centerY" secondItem="Nhk-Y4-RcI" secondAttribute="centerY" constant="12" id="KgW-aM-uUT"/>
@@ -111,21 +109,21 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TGX-v2-Of4">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TGX-v2-Of4">
                                                 <rect key="frame" x="15" y="7" width="29.5" height="29.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="TGX-v2-Of4" secondAttribute="height" multiplier="1:1" id="h58-gb-NIS"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <state key="normal" title="P">
-                                                    <color key="titleColor" systemColor="labelColor"/>
+                                                    <color key="titleColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                                 </state>
                                                 <connections>
                                                     <action selector="isPrepareButtonTapped:" destination="fmi-ND-nuS" eventType="touchUpInside" id="pAP-qG-aBh"/>
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstItem="TGX-v2-Of4" firstAttribute="centerX" secondItem="lNX-mS-vBO" secondAttribute="centerX" id="6ut-c0-tre"/>
                                             <constraint firstItem="TGX-v2-Of4" firstAttribute="width" secondItem="lNX-mS-vBO" secondAttribute="width" multiplier="0.5" id="KuB-dD-SZG"/>
@@ -141,7 +139,7 @@
                             </stackView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7Iu-bN-RtM">
                                 <rect key="frame" x="0.0" y="134" width="414" height="600"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Pz-Vt-NSM" customClass="TotalAmountView" customModule="BoostPocket" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="734" width="414" height="79"/>
@@ -166,7 +164,7 @@
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TiB-LT-87K">
                                         <rect key="frame" x="207" y="8" width="0.5" height="63"/>
-                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="0.5" id="0RV-jI-YhL"/>
                                         </constraints>
@@ -243,8 +241,7 @@
                                 </constraints>
                             </stackView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="gwU-vf-3l1"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="tBh-oz-M9X" firstAttribute="bottom" secondItem="7Iu-bN-RtM" secondAttribute="bottom" constant="-15" id="1aI-qT-0V7"/>
                             <constraint firstItem="Z3N-xh-feq" firstAttribute="leading" secondItem="ALI-AJ-0ck" secondAttribute="trailing" id="3DT-S9-Obs"/>
@@ -273,6 +270,7 @@
                             <constraint firstItem="gwU-vf-3l1" firstAttribute="trailing" secondItem="7Iu-bN-RtM" secondAttribute="trailing" id="wEg-GL-uo8"/>
                             <constraint firstItem="Pfa-3M-wrJ" firstAttribute="width" secondItem="oSf-dj-s8a" secondAttribute="width" multiplier="0.48" id="yFp-Ec-JZ6"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="gwU-vf-3l1"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="지출목록" image="list.bullet" catalog="system" id="wRC-jA-Szt"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -309,7 +307,7 @@
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0DJ-XU-Ifo" customClass="ReportPieChartView" customModule="BoostPocket" customModuleProvider="target">
                                                 <rect key="frame" x="41.5" y="109.5" width="331" height="331"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0DJ-XU-Ifo" secondAttribute="height" multiplier="1:1" id="oZH-4X-xPM"/>
                                                 </constraints>
@@ -320,74 +318,86 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z2v-6p-uXx">
-                                                <rect key="frame" x="113.5" y="537" width="37.5" height="18"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                <color key="textColor" name="basicGrayTextColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6qg-YU-ldr">
-                                                <rect key="frame" x="161" y="490.5" width="211.5" height="19.5"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                                <color key="textColor" name="basicBlackTextColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMc-N8-tE0">
-                                                <rect key="frame" x="161" y="537" width="211.5" height="18"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                <color key="textColor" name="basicGrayTextColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="chd-LF-U5W">
-                                                <rect key="frame" x="41.5" y="525" width="62" height="41.5"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yfq-Sb-hGQ" userLabel="InformationView">
+                                                <rect key="frame" x="41.5" y="470.5" width="331" height="113"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z2v-6p-uXx">
+                                                        <rect key="frame" x="66" y="44.5" width="37.5" height="18"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <color key="textColor" name="basicGrayTextColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6qg-YU-ldr">
+                                                        <rect key="frame" x="113.5" y="0.0" width="217.5" height="19.5"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                        <color key="textColor" name="basicBlackTextColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMc-N8-tE0">
+                                                        <rect key="frame" x="113.5" y="44.5" width="217.5" height="18"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <color key="textColor" name="basicGrayTextColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="chd-LF-U5W">
+                                                        <rect key="frame" x="0.0" y="34.5" width="56" height="37.5"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="chd-LF-U5W" secondAttribute="height" multiplier="3:2" id="9YV-9R-6EE"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gfA-9A-qOs" userLabel="Divider">
+                                                        <rect key="frame" x="0.0" y="112" width="331" height="1"/>
+                                                        <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="1" id="3cT-UB-6X5"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="총 지출" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Ty-TL-dYc">
+                                                        <rect key="frame" x="0.0" y="0.0" width="45.5" height="19.5"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                        <color key="textColor" name="basicBlackTextColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" secondItem="chd-LF-U5W" secondAttribute="height" multiplier="3:2" id="9YV-9R-6EE"/>
-                                                </constraints>
-                                            </imageView>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gfA-9A-qOs" userLabel="Divider">
-                                                <rect key="frame" x="41.5" y="606.5" width="331" height="1"/>
-                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="3cT-UB-6X5"/>
+                                                    <constraint firstItem="3Ty-TL-dYc" firstAttribute="top" secondItem="yfq-Sb-hGQ" secondAttribute="top" id="4Dn-hJ-Rvr"/>
+                                                    <constraint firstAttribute="bottom" secondItem="gfA-9A-qOs" secondAttribute="bottom" id="6mj-Xc-jME"/>
+                                                    <constraint firstItem="chd-LF-U5W" firstAttribute="width" secondItem="yfq-Sb-hGQ" secondAttribute="width" multiplier="0.15" constant="6.3500000000000014" id="Abh-Gr-iLJ"/>
+                                                    <constraint firstItem="chd-LF-U5W" firstAttribute="top" secondItem="3Ty-TL-dYc" secondAttribute="bottom" constant="15" id="B2l-pJ-ulV"/>
+                                                    <constraint firstAttribute="trailing" secondItem="6qg-YU-ldr" secondAttribute="trailing" id="EGN-SP-6Jz"/>
+                                                    <constraint firstAttribute="trailing" secondItem="gfA-9A-qOs" secondAttribute="trailing" id="I6I-8N-5tg"/>
+                                                    <constraint firstItem="3Ty-TL-dYc" firstAttribute="leading" secondItem="yfq-Sb-hGQ" secondAttribute="leading" id="Kdy-Ak-h2i"/>
+                                                    <constraint firstItem="chd-LF-U5W" firstAttribute="leading" secondItem="3Ty-TL-dYc" secondAttribute="leading" id="X1P-K6-rpc"/>
+                                                    <constraint firstItem="LMc-N8-tE0" firstAttribute="trailing" secondItem="6qg-YU-ldr" secondAttribute="trailing" id="Zlt-m9-QiJ"/>
+                                                    <constraint firstItem="gfA-9A-qOs" firstAttribute="leading" secondItem="yfq-Sb-hGQ" secondAttribute="leading" id="c7Q-RC-jyI"/>
+                                                    <constraint firstItem="z2v-6p-uXx" firstAttribute="centerY" secondItem="chd-LF-U5W" secondAttribute="centerY" id="diC-Va-prC"/>
+                                                    <constraint firstItem="z2v-6p-uXx" firstAttribute="leading" secondItem="chd-LF-U5W" secondAttribute="trailing" constant="10" id="guK-7d-pEm"/>
+                                                    <constraint firstItem="gfA-9A-qOs" firstAttribute="top" secondItem="chd-LF-U5W" secondAttribute="bottom" constant="40" id="jq5-US-9ER"/>
+                                                    <constraint firstItem="LMc-N8-tE0" firstAttribute="centerY" secondItem="chd-LF-U5W" secondAttribute="centerY" id="kdf-jE-NYT"/>
+                                                    <constraint firstItem="6qg-YU-ldr" firstAttribute="leading" secondItem="z2v-6p-uXx" secondAttribute="trailing" constant="10" id="kxC-N4-KhP"/>
+                                                    <constraint firstItem="LMc-N8-tE0" firstAttribute="leading" secondItem="z2v-6p-uXx" secondAttribute="trailing" constant="10" id="muR-6J-9a9"/>
+                                                    <constraint firstItem="6qg-YU-ldr" firstAttribute="centerY" secondItem="3Ty-TL-dYc" secondAttribute="centerY" id="uBr-aX-XQa"/>
                                                 </constraints>
                                             </view>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="총 지출" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Ty-TL-dYc">
-                                                <rect key="frame" x="41.5" y="490.5" width="45.5" height="19.5"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                                <color key="textColor" name="basicBlackTextColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="t7t-L2-t41">
-                                                <rect key="frame" x="41.5" y="627.5" width="331" height="94.5"/>
+                                                <rect key="frame" x="41.5" y="603.5" width="331" height="118.5"/>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
-                                            <constraint firstItem="LMc-N8-tE0" firstAttribute="centerY" secondItem="chd-LF-U5W" secondAttribute="centerY" id="20E-r8-vSG"/>
-                                            <constraint firstItem="gfA-9A-qOs" firstAttribute="top" secondItem="chd-LF-U5W" secondAttribute="bottom" constant="40" id="2t1-3U-iRn"/>
-                                            <constraint firstItem="chd-LF-U5W" firstAttribute="top" secondItem="3Ty-TL-dYc" secondAttribute="bottom" constant="15" id="3Tb-Dd-9Dh"/>
-                                            <constraint firstItem="t7t-L2-t41" firstAttribute="leading" secondItem="gfA-9A-qOs" secondAttribute="leading" id="70e-Nz-cmx"/>
                                             <constraint firstItem="0DJ-XU-Ifo" firstAttribute="top" secondItem="Kar-kh-qej" secondAttribute="bottom" constant="50" id="86E-NW-Mx1"/>
-                                            <constraint firstItem="3Ty-TL-dYc" firstAttribute="top" secondItem="0DJ-XU-Ifo" secondAttribute="bottom" constant="50" id="8hL-68-0vY"/>
-                                            <constraint firstItem="LMc-N8-tE0" firstAttribute="trailing" secondItem="6qg-YU-ldr" secondAttribute="trailing" id="B1w-5i-DtK"/>
                                             <constraint firstAttribute="bottom" secondItem="t7t-L2-t41" secondAttribute="bottom" constant="20" id="EBB-Jh-xSa"/>
-                                            <constraint firstItem="6qg-YU-ldr" firstAttribute="centerY" secondItem="3Ty-TL-dYc" secondAttribute="centerY" id="Fyt-7E-bRP"/>
-                                            <constraint firstItem="gfA-9A-qOs" firstAttribute="leading" secondItem="0DJ-XU-Ifo" secondAttribute="leading" id="LnS-2Y-b9k"/>
-                                            <constraint firstItem="t7t-L2-t41" firstAttribute="top" secondItem="gfA-9A-qOs" secondAttribute="bottom" constant="20" id="N9U-xa-39V"/>
-                                            <constraint firstItem="LMc-N8-tE0" firstAttribute="leading" secondItem="z2v-6p-uXx" secondAttribute="trailing" constant="10" id="Oji-SQ-dLw"/>
-                                            <constraint firstItem="6qg-YU-ldr" firstAttribute="trailing" secondItem="0DJ-XU-Ifo" secondAttribute="trailing" id="Qh3-jD-LTc"/>
+                                            <constraint firstItem="t7t-L2-t41" firstAttribute="top" secondItem="yfq-Sb-hGQ" secondAttribute="bottom" constant="20" id="EST-65-yWy"/>
+                                            <constraint firstItem="t7t-L2-t41" firstAttribute="trailing" secondItem="yfq-Sb-hGQ" secondAttribute="trailing" id="MUK-M5-pR1"/>
                                             <constraint firstItem="Kar-kh-qej" firstAttribute="centerX" secondItem="6BA-mJ-pxK" secondAttribute="centerX" id="Tmt-cc-xgB"/>
+                                            <constraint firstItem="yfq-Sb-hGQ" firstAttribute="leading" secondItem="0DJ-XU-Ifo" secondAttribute="leading" id="TwS-M2-Hwq"/>
                                             <constraint firstItem="0DJ-XU-Ifo" firstAttribute="width" secondItem="6BA-mJ-pxK" secondAttribute="width" multiplier="0.8" id="Udd-OE-DM8"/>
-                                            <constraint firstItem="z2v-6p-uXx" firstAttribute="leading" secondItem="chd-LF-U5W" secondAttribute="trailing" constant="10" id="XfI-kv-Qff"/>
-                                            <constraint firstItem="chd-LF-U5W" firstAttribute="leading" secondItem="3Ty-TL-dYc" secondAttribute="leading" id="apn-fn-mil"/>
-                                            <constraint firstItem="chd-LF-U5W" firstAttribute="width" secondItem="6BA-mJ-pxK" secondAttribute="width" multiplier="0.15" id="eZu-E6-VGt"/>
-                                            <constraint firstItem="t7t-L2-t41" firstAttribute="trailing" secondItem="gfA-9A-qOs" secondAttribute="trailing" id="jcT-Vp-wbe"/>
                                             <constraint firstItem="Kar-kh-qej" firstAttribute="top" secondItem="6BA-mJ-pxK" secondAttribute="top" constant="40" id="lb1-xy-HqV"/>
+                                            <constraint firstItem="yfq-Sb-hGQ" firstAttribute="top" secondItem="0DJ-XU-Ifo" secondAttribute="bottom" constant="30" id="nnQ-y7-EKF"/>
                                             <constraint firstItem="0DJ-XU-Ifo" firstAttribute="centerX" secondItem="6BA-mJ-pxK" secondAttribute="centerX" id="ptU-Ct-sQE"/>
-                                            <constraint firstItem="gfA-9A-qOs" firstAttribute="trailing" secondItem="0DJ-XU-Ifo" secondAttribute="trailing" id="rWU-ls-4Gn"/>
-                                            <constraint firstItem="z2v-6p-uXx" firstAttribute="centerY" secondItem="chd-LF-U5W" secondAttribute="centerY" id="xes-Mj-QJ1"/>
-                                            <constraint firstItem="6qg-YU-ldr" firstAttribute="leading" secondItem="z2v-6p-uXx" secondAttribute="trailing" constant="10" id="y1f-ct-pqn"/>
-                                            <constraint firstItem="3Ty-TL-dYc" firstAttribute="leading" secondItem="0DJ-XU-Ifo" secondAttribute="leading" id="zy1-YF-1my"/>
+                                            <constraint firstItem="yfq-Sb-hGQ" firstAttribute="trailing" secondItem="0DJ-XU-Ifo" secondAttribute="trailing" id="rVh-dw-2mS"/>
+                                            <constraint firstItem="t7t-L2-t41" firstAttribute="leading" secondItem="yfq-Sb-hGQ" secondAttribute="leading" id="xG5-Kt-sd6"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -400,20 +410,21 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="dz2-Wq-4eW"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="Ym4-MA-8an" firstAttribute="top" secondItem="dz2-Wq-4eW" secondAttribute="top" id="2Nb-Rf-Sla"/>
                             <constraint firstItem="dz2-Wq-4eW" firstAttribute="bottom" secondItem="Ym4-MA-8an" secondAttribute="bottom" id="aRZ-Mq-BQe"/>
                             <constraint firstItem="dz2-Wq-4eW" firstAttribute="trailing" secondItem="Ym4-MA-8an" secondAttribute="trailing" id="fgo-5M-GzJ"/>
                             <constraint firstItem="Ym4-MA-8an" firstAttribute="leading" secondItem="dz2-Wq-4eW" secondAttribute="leading" id="jCR-YY-O6y"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="dz2-Wq-4eW"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="리포트" image="chart.pie.fill" catalog="system" id="hU1-KU-wkB"/>
                     <connections>
                         <outlet property="currencyCodeLabel" destination="z2v-6p-uXx" id="X9p-fK-7Zu"/>
                         <outlet property="expensesStackView" destination="t7t-L2-t41" id="fW6-8y-y4t"/>
                         <outlet property="flagImageView" destination="chd-LF-U5W" id="sMf-8H-YOj"/>
+                        <outlet property="informationView" destination="yfq-Sb-hGQ" id="g1F-kT-yoA"/>
                         <outlet property="reportPieChartView" destination="0DJ-XU-Ifo" id="4Im-Qf-CD4"/>
                         <outlet property="summaryLabel" destination="Kar-kh-qej" id="UcF-zN-Fii"/>
                         <outlet property="totalExpenseKRWLabel" destination="6qg-YU-ldr" id="dlw-5w-FV7"/>
@@ -443,15 +454,15 @@
                                             <subviews>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ngs-Bg-0Xj">
                                                     <rect key="frame" x="10" y="20" width="354" height="268"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                    <color key="textColor" systemColor="labelColor"/>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                    <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 </textView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="lvB-TX-H2s">
                                                     <rect key="frame" x="0.0" y="288" width="374" height="70"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-8R-MDG">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-8R-MDG">
                                                             <rect key="frame" x="0.0" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <state key="normal" title="취소">
@@ -461,7 +472,7 @@
                                                                 <action selector="cancelButtonTapped:" destination="7AX-5V-hys" eventType="touchUpInside" id="pJf-ns-WVd"/>
                                                             </connections>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Weu-7S-Dg6">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Weu-7S-Dg6">
                                                             <rect key="frame" x="187" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <state key="normal" title="완료">
@@ -477,7 +488,7 @@
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                             <constraints>
                                                 <constraint firstItem="Ngs-Bg-0Xj" firstAttribute="leading" secondItem="cfT-us-jdV" secondAttribute="leading" constant="10" id="HOk-Hq-3mB"/>
                                                 <constraint firstItem="Ngs-Bg-0Xj" firstAttribute="top" secondItem="cfT-us-jdV" secondAttribute="top" constant="20" id="IbE-4r-ZTp"/>
@@ -503,8 +514,7 @@
                                 <blurEffect style="dark"/>
                             </visualEffectView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="tsh-cb-G6F"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="2y1-T4-y8R" firstAttribute="leading" secondItem="nnu-cz-oT4" secondAttribute="leading" id="IUN-qK-PlL"/>
                             <constraint firstAttribute="bottom" secondItem="2y1-T4-y8R" secondAttribute="bottom" id="Oha-3E-sDm"/>
@@ -512,6 +522,7 @@
                             <constraint firstAttribute="trailing" secondItem="2y1-T4-y8R" secondAttribute="trailing" id="kWs-Fn-Nle"/>
                             <constraint firstItem="cfT-us-jdV" firstAttribute="height" secondItem="nnu-cz-oT4" secondAttribute="height" multiplier="0.4" id="yCN-Ju-RMh"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="tsh-cb-G6F"/>
                     </view>
                     <connections>
                         <outlet property="memoTextView" destination="Ngs-Bg-0Xj" id="MC5-YO-gnw"/>
@@ -707,13 +718,13 @@
                                                                                 </constraints>
                                                                             </view>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 %" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XiF-QM-NZR">
-                                                                                <rect key="frame" x="10" y="6" width="27" height="18"/>
+                                                                                <rect key="frame" x="10" y="6" width="26" height="18"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                         </subviews>
-                                                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                                        <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <constraints>
                                                                             <constraint firstItem="Cgj-k5-VFd" firstAttribute="top" secondItem="qvF-Ok-csh" secondAttribute="top" id="Flf-h1-W0M"/>
                                                                             <constraint firstItem="XiF-QM-NZR" firstAttribute="centerY" secondItem="qvF-Ok-csh" secondAttribute="centerY" id="YBr-5F-AuR"/>
@@ -727,13 +738,13 @@
                                                                         <rect key="frame" x="0.0" y="104" width="374" height="16"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="₩ 25,000 사용" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V5d-JZ-sid">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="185.5" height="16"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="185" height="16"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" name="basicBlackTextColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KRW 15,000 남음/₩ 23,000 초과" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rmn-Fr-kXg">
-                                                                                <rect key="frame" x="185.5" y="0.0" width="188.5" height="16"/>
+                                                                                <rect key="frame" x="185" y="0.0" width="189" height="16"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" name="basicBlackTextColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -768,7 +779,7 @@
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eHl-w2-LWW" userLabel="Button View">
                                                                 <rect key="frame" x="0.0" y="1322" width="374" height="37.5"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIM-lz-bbD" userLabel="여행 삭제하기">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIM-lz-bbD" userLabel="여행 삭제하기">
                                                                         <rect key="frame" x="131" y="0.0" width="112" height="37.5"/>
                                                                         <color key="backgroundColor" name="deleteButtonColor"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
@@ -786,7 +797,7 @@
                                                                         </connections>
                                                                     </button>
                                                                 </subviews>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                                 <constraints>
                                                                     <constraint firstItem="eIM-lz-bbD" firstAttribute="top" secondItem="eHl-w2-LWW" secondAttribute="top" id="GmL-Jd-PP6"/>
                                                                     <constraint firstAttribute="width" secondItem="eHl-w2-LWW" secondAttribute="height" multiplier="10:1" id="MIb-du-ecy"/>
@@ -804,7 +815,7 @@
                                                         </constraints>
                                                     </stackView>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="bottom" secondItem="Ma0-RF-0Rk" secondAttribute="bottom" constant="20" id="0mA-rw-gX3"/>
                                                     <constraint firstItem="Ma0-RF-0Rk" firstAttribute="leading" secondItem="6aw-iA-A5G" secondAttribute="leading" constant="20" id="6Zs-hF-1E0"/>
@@ -821,7 +832,7 @@
                                         </constraints>
                                     </scrollView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstItem="ux4-FQ-XbC" firstAttribute="leading" secondItem="YI3-ni-eQX" secondAttribute="leading" id="4ab-jw-mb0"/>
                                     <constraint firstAttribute="trailing" secondItem="6aw-iA-A5G" secondAttribute="trailing" id="BRO-JO-oy2"/>
@@ -831,14 +842,14 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="GL9-dr-PWQ"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="YI3-ni-eQX" firstAttribute="top" secondItem="GL9-dr-PWQ" secondAttribute="top" id="Z2W-2W-yeL"/>
                             <constraint firstItem="GL9-dr-PWQ" firstAttribute="trailing" secondItem="YI3-ni-eQX" secondAttribute="trailing" id="ZjF-4e-1c4"/>
                             <constraint firstItem="YI3-ni-eQX" firstAttribute="leading" secondItem="GL9-dr-PWQ" secondAttribute="leading" id="epO-JR-yDD"/>
                             <constraint firstItem="GL9-dr-PWQ" firstAttribute="bottom" secondItem="YI3-ni-eQX" secondAttribute="bottom" id="ysR-Y0-u4J"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="GL9-dr-PWQ"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="여행프로필" image="airplane" catalog="system" id="Ln5-3b-m3G"/>
                     <connections>
@@ -901,7 +912,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="EUc-EQ-1Pe">
                                                     <rect key="frame" x="0.0" y="109" width="374" height="70"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vt1-wB-b2C">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vt1-wB-b2C">
                                                             <rect key="frame" x="0.0" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <state key="normal" title="취소">
@@ -911,7 +922,7 @@
                                                                 <action selector="cancelButtonTapped:" destination="oiW-sK-s0f" eventType="touchUpInside" id="g3E-wQ-axe"/>
                                                             </connections>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ha6-Yg-38H">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ha6-Yg-38H">
                                                             <rect key="frame" x="187" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <state key="normal" title="완료">
@@ -932,7 +943,7 @@
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                             <constraints>
                                                 <constraint firstItem="Xft-Lx-5eQ" firstAttribute="top" secondItem="h3p-Pl-e1l" secondAttribute="top" constant="20" id="EDw-D1-zt1"/>
                                                 <constraint firstAttribute="bottom" secondItem="EUc-EQ-1Pe" secondAttribute="bottom" id="Nfh-nV-TtX"/>
@@ -958,8 +969,7 @@
                                 <blurEffect style="dark"/>
                             </visualEffectView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="TZg-A5-mcJ"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="ufc-1i-Y1E" firstAttribute="top" secondItem="Giw-yE-nho" secondAttribute="top" id="32L-jQ-E88"/>
                             <constraint firstItem="h3p-Pl-e1l" firstAttribute="height" secondItem="Giw-yE-nho" secondAttribute="height" multiplier="0.2" id="Hpq-L1-ir2"/>
@@ -967,6 +977,7 @@
                             <constraint firstItem="ufc-1i-Y1E" firstAttribute="leading" secondItem="Giw-yE-nho" secondAttribute="leading" id="ZbB-hu-HEa"/>
                             <constraint firstAttribute="bottom" secondItem="ufc-1i-Y1E" secondAttribute="bottom" id="xc4-ZR-xYy"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="TZg-A5-mcJ"/>
                     </view>
                     <connections>
                         <outlet property="titleTextField" destination="Xft-Lx-5eQ" id="NDF-qG-jZ7"/>
@@ -986,7 +997,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020년 11월 17일 4:08:51" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ImO-lf-XQ3">
-                                <rect key="frame" x="123" y="59" width="168" height="18"/>
+                                <rect key="frame" x="123" y="59" width="168.5" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -1004,7 +1015,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="US$ 7.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4wV-KP-wum">
-                                                <rect key="frame" x="154.5" y="61.5" width="105.5" height="30"/>
+                                                <rect key="frame" x="154" y="61.5" width="106.5" height="30"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
                                                 <color key="textColor" name="deleteButtonColor"/>
                                                 <nil key="highlightedColor"/>
@@ -1017,7 +1028,7 @@
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Ar-ih-n1d" userLabel="seperator">
                                                 <rect key="frame" x="20" y="132.5" width="374" height="1"/>
-                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Fdc-go-kXJ"/>
                                                 </constraints>
@@ -1078,13 +1089,13 @@
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="예산명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yxl-gY-oUx">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="339.5" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="339" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USD" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EdU-9L-4nm">
-                                                                        <rect key="frame" x="339.5" y="0.0" width="34.5" height="20.5"/>
+                                                                        <rect key="frame" x="339" y="0.0" width="35" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
@@ -1095,13 +1106,13 @@
                                                                 <rect key="frame" x="0.0" y="28.5" width="374" height="20.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="환율" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LBI-bm-1g8">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="201" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="199.5" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USD 1.00 = KRW 1,096" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Khp-bb-Ych">
-                                                                        <rect key="frame" x="201" y="0.0" width="173" height="20.5"/>
+                                                                        <rect key="frame" x="199.5" y="0.0" width="174.5" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
@@ -1121,7 +1132,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="uOJ-NV-xEH" userLabel="Button Stack View">
                                                 <rect key="frame" x="124" y="776.5" width="166" height="81"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Qv-Go-eCZ">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Qv-Go-eCZ">
                                                         <rect key="frame" x="0.0" y="0.0" width="166" height="38"/>
                                                         <color key="backgroundColor" name="lightMainColor"/>
                                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="0.0" maxY="10"/>
@@ -1137,7 +1148,7 @@
                                                             <action selector="editButtonTapped:" destination="n0l-Qt-t7z" eventType="touchUpInside" id="leZ-S8-6gh"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6DE-yh-NZb">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6DE-yh-NZb">
                                                         <rect key="frame" x="0.0" y="43" width="166" height="38"/>
                                                         <color key="backgroundColor" name="deleteButtonColor"/>
                                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="0.0" maxY="10"/>
@@ -1156,7 +1167,7 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstItem="4wV-KP-wum" firstAttribute="top" secondItem="3iv-Zv-NJB" secondAttribute="bottom" constant="10" id="5zx-Mf-QXy"/>
                                             <constraint firstItem="4wV-KP-wum" firstAttribute="centerX" secondItem="p69-4J-mh8" secondAttribute="centerX" id="6Kw-9G-1Re"/>
@@ -1189,7 +1200,7 @@
                                     <constraint firstAttribute="trailing" secondItem="p69-4J-mh8" secondAttribute="trailing" id="irl-UI-GqD"/>
                                 </constraints>
                             </scrollView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eHk-JU-XwN">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eHk-JU-XwN">
                                 <rect key="frame" x="0.0" y="821" width="414" height="41"/>
                                 <color key="backgroundColor" name="mainColor"/>
                                 <state key="normal" title="닫기">
@@ -1204,8 +1215,7 @@
                                 <color key="backgroundColor" name="mainColor"/>
                             </view>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="qNU-nu-0oe"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="qNU-nu-0oe" firstAttribute="bottom" secondItem="eHk-JU-XwN" secondAttribute="bottom" id="1Qx-0Q-w66"/>
                             <constraint firstItem="nEJ-zQ-SvF" firstAttribute="top" secondItem="ImO-lf-XQ3" secondAttribute="bottom" constant="20" id="APM-Je-8rx"/>
@@ -1224,6 +1234,7 @@
                             <constraint firstItem="eHk-JU-XwN" firstAttribute="leading" secondItem="qNU-nu-0oe" secondAttribute="leading" id="wzq-CE-hr4"/>
                             <constraint firstItem="qNU-nu-0oe" firstAttribute="trailing" secondItem="eHk-JU-XwN" secondAttribute="trailing" id="zc8-mA-Vls"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="qNU-nu-0oe"/>
                     </view>
                     <connections>
                         <outlet property="amountLabel" destination="4wV-KP-wum" id="ZlA-ef-kD6"/>
@@ -1249,7 +1260,7 @@
     </scenes>
     <resources>
         <image name="airplane" catalog="system" width="128" height="115"/>
-        <image name="chart.pie.fill" catalog="system" width="128" height="121"/>
+        <image name="chart.pie.fill" catalog="system" width="128" height="124"/>
         <image name="historyImage" width="512" height="512"/>
         <image name="isPrepareFalse" width="64" height="64"/>
         <image name="list.bullet" catalog="system" width="128" height="88"/>
@@ -1279,17 +1290,5 @@
         <namedColor name="mainColor">
             <color red="0.46299999952316284" green="0.69800001382827759" blue="0.89800000190734863" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="opaqueSeparatorColor">
-            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray5Color">
-            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
### Issue Number
Close #213 

### 변경사항
- 파이차트, 정보 뷰를 Hidden시키고 summary 레이블 내용 변경

### 새로운 기능
![스크린샷 2020-12-10 오후 5 11 36](https://user-images.githubusercontent.com/35067611/101739408-d2f64a00-3b0a-11eb-8daf-b5dbb9db4c56.png)
![스크린샷 2020-12-10 오후 5 11 31](https://user-images.githubusercontent.com/35067611/101739418-d689d100-3b0a-11eb-822d-17b59fb66b16.png)

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
