### PR TITLE
프로필 화면 예산 관련 디자인 수정

### DIFF
--- a/BoostPocket/BoostPocket/TravelDetailScene/ProfileScene/TravelProfileViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/ProfileScene/TravelProfileViewController.swift
@@ -25,6 +25,7 @@ class TravelProfileViewController: UIViewController {
     @IBOutlet weak var startDatePicker: UIDatePicker!
     @IBOutlet weak var endDatePicker: UIDatePicker!
     @IBOutlet weak var coverImage: UIImageView!
+    @IBOutlet weak var progressBar: UIView!
     @IBOutlet weak var progressBarWidthConstraint: NSLayoutConstraint!
     @IBOutlet weak var progressBarBackground: UIView!
     @IBOutlet weak var progressPercentageLabel: UILabel!
@@ -58,7 +59,7 @@ class TravelProfileViewController: UIViewController {
         super.viewDidLayoutSubviews()
         guard let travelItemViewModel = travelItemViewModel else { return }
         let percentage = travelItemViewModel.expensePercentage
-        progressPercentageLabel.text = String(format: "%d%%", Int(percentage * 100))
+        progressPercentageLabel.text = String(format: "%lld%%", Int(percentage * 100))
         
         progressBarWidthConstraint.constant = percentage > 1 ? progressBarBackground.frame.width : progressBarBackground.frame.width * CGFloat(percentage)
     }
@@ -87,6 +88,10 @@ class TravelProfileViewController: UIViewController {
         let remain = income - expense
         remainLabel.text = remain < 0 ? id.currencySymbol + " " + (-remain).getCurrencyFormat(identifier: id) + " 초과" :
             id.currencySymbol + " " + remain.getCurrencyFormat(identifier: id) + " 남음"
+        remainLabel.textColor = remain < 0 ? UIColor(named: "deleteTextColor") : UIColor(named: "basicGrayTextColor")
+        progressBar.backgroundColor = remain < 0 ? UIColor(named: "expenseBackgroundColor") : UIColor(named: "mainColor")
+        progressBarBackground.layer.cornerRadius = progressBarBackground.bounds.height * 0.3
+        progressBar.layer.cornerRadius = progressBarBackground.bounds.height * 0.3
     }
     
     @IBAction func deleteButtonTapped(_ sender: UIButton) {

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,7 +21,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ALI-AJ-0ck" userLabel="Divider">
                                 <rect key="frame" x="118.5" y="50" width="0.0" height="47"/>
-                                <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="0.29999999999999999" id="jZE-uh-4VG"/>
                                 </constraints>
@@ -56,7 +58,7 @@
                                         </constraints>
                                     </scrollView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="NrH-bA-9YK" secondAttribute="bottom" id="BeG-kR-7Bc"/>
                                     <constraint firstItem="jFB-Ve-ziB" firstAttribute="height" secondItem="Z3N-xh-feq" secondAttribute="height" id="Uxo-A3-1Jj"/>
@@ -77,21 +79,21 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4RM-9s-J1O">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4RM-9s-J1O">
                                                 <rect key="frame" x="15" y="7" width="29.5" height="29.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="4RM-9s-J1O" secondAttribute="height" multiplier="1:1" id="y2f-Gy-RwD"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <state key="normal" title="A">
-                                                    <color key="titleColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="titleColor" systemColor="labelColor"/>
                                                 </state>
                                                 <connections>
                                                     <action selector="isPrepareButtonTapped:" destination="fmi-ND-nuS" eventType="touchUpInside" id="0Xs-Hi-ViN"/>
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="4RM-9s-J1O" firstAttribute="width" secondItem="Nhk-Y4-RcI" secondAttribute="width" multiplier="0.5" id="AqU-4x-YGi"/>
                                             <constraint firstItem="PJt-Ce-JhI" firstAttribute="centerY" secondItem="Nhk-Y4-RcI" secondAttribute="centerY" constant="12" id="KgW-aM-uUT"/>
@@ -109,21 +111,21 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TGX-v2-Of4">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TGX-v2-Of4">
                                                 <rect key="frame" x="15" y="7" width="29.5" height="29.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="TGX-v2-Of4" secondAttribute="height" multiplier="1:1" id="h58-gb-NIS"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <state key="normal" title="P">
-                                                    <color key="titleColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="titleColor" systemColor="labelColor"/>
                                                 </state>
                                                 <connections>
                                                     <action selector="isPrepareButtonTapped:" destination="fmi-ND-nuS" eventType="touchUpInside" id="pAP-qG-aBh"/>
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="TGX-v2-Of4" firstAttribute="centerX" secondItem="lNX-mS-vBO" secondAttribute="centerX" id="6ut-c0-tre"/>
                                             <constraint firstItem="TGX-v2-Of4" firstAttribute="width" secondItem="lNX-mS-vBO" secondAttribute="width" multiplier="0.5" id="KuB-dD-SZG"/>
@@ -139,7 +141,7 @@
                             </stackView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7Iu-bN-RtM">
                                 <rect key="frame" x="0.0" y="134" width="414" height="600"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Pz-Vt-NSM" customClass="TotalAmountView" customModule="BoostPocket" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="734" width="414" height="79"/>
@@ -164,7 +166,7 @@
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TiB-LT-87K">
                                         <rect key="frame" x="207" y="8" width="0.5" height="63"/>
-                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="0.5" id="0RV-jI-YhL"/>
                                         </constraints>
@@ -247,7 +249,8 @@
                                 </constraints>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="gwU-vf-3l1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="tBh-oz-M9X" firstAttribute="bottom" secondItem="7Iu-bN-RtM" secondAttribute="bottom" constant="-15" id="1aI-qT-0V7"/>
                             <constraint firstItem="Ymo-4K-Sav" firstAttribute="centerX" secondItem="oSf-dj-s8a" secondAttribute="centerX" id="1ap-sW-gdw"/>
@@ -270,15 +273,14 @@
                             <constraint firstItem="gwU-vf-3l1" firstAttribute="trailing" secondItem="Z3N-xh-feq" secondAttribute="trailing" id="lBy-LH-pwj"/>
                             <constraint firstItem="TlZ-ef-Dwf" firstAttribute="width" secondItem="gwU-vf-3l1" secondAttribute="width" multiplier="2/7" id="lbN-Wz-cmH"/>
                             <constraint firstItem="TlZ-ef-Dwf" firstAttribute="leading" secondItem="gwU-vf-3l1" secondAttribute="leading" id="le0-lN-HEI"/>
-                            <constraint firstItem="Ymo-4K-Sav" firstAttribute="centerY" secondItem="oSf-dj-s8a" secondAttribute="centerY" id="pRh-vf-ufV"/>
                             <constraint firstItem="ALI-AJ-0ck" firstAttribute="centerY" secondItem="TlZ-ef-Dwf" secondAttribute="centerY" id="llR-96-pC3"/>
+                            <constraint firstItem="Ymo-4K-Sav" firstAttribute="centerY" secondItem="oSf-dj-s8a" secondAttribute="centerY" id="pRh-vf-ufV"/>
                             <constraint firstItem="ALI-AJ-0ck" firstAttribute="height" secondItem="TlZ-ef-Dwf" secondAttribute="height" multiplier="0.8" id="qGQ-K3-9Qh"/>
                             <constraint firstItem="jDJ-DO-0v7" firstAttribute="leading" secondItem="gwU-vf-3l1" secondAttribute="leading" id="qWB-nK-D1U"/>
                             <constraint firstItem="HQY-uN-Bt6" firstAttribute="width" secondItem="oSf-dj-s8a" secondAttribute="width" multiplier="0.98" priority="750" id="uHS-Xz-AaB"/>
                             <constraint firstItem="gwU-vf-3l1" firstAttribute="trailing" secondItem="7Iu-bN-RtM" secondAttribute="trailing" id="wEg-GL-uo8"/>
                             <constraint firstItem="Pfa-3M-wrJ" firstAttribute="width" secondItem="oSf-dj-s8a" secondAttribute="width" multiplier="0.48" id="yFp-Ec-JZ6"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="gwU-vf-3l1"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="지출목록" image="list.bullet" catalog="system" id="wRC-jA-Szt"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -316,7 +318,7 @@
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0DJ-XU-Ifo" customClass="ReportPieChartView" customModule="BoostPocket" customModuleProvider="target">
                                                 <rect key="frame" x="41.5" y="109.5" width="331" height="331"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0DJ-XU-Ifo" secondAttribute="height" multiplier="1:1" id="oZH-4X-xPM"/>
                                                 </constraints>
@@ -356,7 +358,7 @@
                                                     </imageView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gfA-9A-qOs" userLabel="Divider">
                                                         <rect key="frame" x="0.0" y="112" width="331" height="1"/>
-                                                        <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="1" id="3cT-UB-6X5"/>
                                                         </constraints>
@@ -368,7 +370,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstItem="3Ty-TL-dYc" firstAttribute="top" secondItem="yfq-Sb-hGQ" secondAttribute="top" id="4Dn-hJ-Rvr"/>
                                                     <constraint firstAttribute="bottom" secondItem="gfA-9A-qOs" secondAttribute="bottom" id="6mj-Xc-jME"/>
@@ -393,7 +395,7 @@
                                                 <rect key="frame" x="41.5" y="603.5" width="331" height="118.5"/>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="0DJ-XU-Ifo" firstAttribute="top" secondItem="Kar-kh-qej" secondAttribute="bottom" constant="50" id="86E-NW-Mx1"/>
                                             <constraint firstAttribute="bottom" secondItem="t7t-L2-t41" secondAttribute="bottom" constant="20" id="EBB-Jh-xSa"/>
@@ -419,14 +421,14 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="dz2-Wq-4eW"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Ym4-MA-8an" firstAttribute="top" secondItem="dz2-Wq-4eW" secondAttribute="top" id="2Nb-Rf-Sla"/>
                             <constraint firstItem="dz2-Wq-4eW" firstAttribute="bottom" secondItem="Ym4-MA-8an" secondAttribute="bottom" id="aRZ-Mq-BQe"/>
                             <constraint firstItem="dz2-Wq-4eW" firstAttribute="trailing" secondItem="Ym4-MA-8an" secondAttribute="trailing" id="fgo-5M-GzJ"/>
                             <constraint firstItem="Ym4-MA-8an" firstAttribute="leading" secondItem="dz2-Wq-4eW" secondAttribute="leading" id="jCR-YY-O6y"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="dz2-Wq-4eW"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="리포트" image="chart.pie.fill" catalog="system" id="hU1-KU-wkB"/>
                     <connections>
@@ -463,15 +465,15 @@
                                             <subviews>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ngs-Bg-0Xj">
                                                     <rect key="frame" x="10" y="20" width="354" height="268"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                                    <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 </textView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="lvB-TX-H2s">
                                                     <rect key="frame" x="0.0" y="288" width="374" height="70"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-8R-MDG">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-8R-MDG">
                                                             <rect key="frame" x="0.0" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <state key="normal" title="취소">
@@ -481,7 +483,7 @@
                                                                 <action selector="cancelButtonTapped:" destination="7AX-5V-hys" eventType="touchUpInside" id="pJf-ns-WVd"/>
                                                             </connections>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Weu-7S-Dg6">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Weu-7S-Dg6">
                                                             <rect key="frame" x="187" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <state key="normal" title="완료">
@@ -497,7 +499,7 @@
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstItem="Ngs-Bg-0Xj" firstAttribute="leading" secondItem="cfT-us-jdV" secondAttribute="leading" constant="10" id="HOk-Hq-3mB"/>
                                                 <constraint firstItem="Ngs-Bg-0Xj" firstAttribute="top" secondItem="cfT-us-jdV" secondAttribute="top" constant="20" id="IbE-4r-ZTp"/>
@@ -523,7 +525,8 @@
                                 <blurEffect style="dark"/>
                             </visualEffectView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="tsh-cb-G6F"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="2y1-T4-y8R" firstAttribute="leading" secondItem="nnu-cz-oT4" secondAttribute="leading" id="IUN-qK-PlL"/>
                             <constraint firstAttribute="bottom" secondItem="2y1-T4-y8R" secondAttribute="bottom" id="Oha-3E-sDm"/>
@@ -531,7 +534,6 @@
                             <constraint firstAttribute="trailing" secondItem="2y1-T4-y8R" secondAttribute="trailing" id="kWs-Fn-Nle"/>
                             <constraint firstItem="cfT-us-jdV" firstAttribute="height" secondItem="nnu-cz-oT4" secondAttribute="height" multiplier="0.4" id="yCN-Ju-RMh"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="tsh-cb-G6F"/>
                     </view>
                     <connections>
                         <outlet property="memoTextView" destination="Ngs-Bg-0Xj" id="MC5-YO-gnw"/>
@@ -557,16 +559,16 @@
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="769"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6aw-iA-A5G" userLabel="ContentView">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="1399.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="417" height="1402.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Ma0-RF-0Rk" userLabel="super stackview">
-                                                        <rect key="frame" x="20" y="20" width="374" height="1359.5"/>
+                                                        <rect key="frame" x="20" y="20" width="377" height="1362.5"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1yc-zB-dTX" userLabel="Title Stack View">
-                                                                <rect key="frame" x="0.0" y="0.0" width="374" height="90"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="377" height="90"/>
                                                                 <subviews>
                                                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="여행 타이틀" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="073-uU-kbJ">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="20"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="20" id="87o-98-Ide"/>
                                                                         </constraints>
@@ -575,7 +577,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이곳에는 여행에 대한 간단한 메모를 남길 수 있습니다.여기를 눌러 메모해보세요." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BZe-HI-OZv">
-                                                                        <rect key="frame" x="0.0" y="30" width="374" height="60"/>
+                                                                        <rect key="frame" x="0.0" y="30" width="377" height="60"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="DWK-bU-FiX"/>
                                                                         </constraints>
@@ -588,11 +590,11 @@
                                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="90" id="3Pi-a3-nua"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="zAg-ZF-cHX">
-                                                                <rect key="frame" x="0.0" y="120" width="374" height="80"/>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="zAg-ZF-cHX" userLabel="Country Stack View">
+                                                                <rect key="frame" x="0.0" y="120" width="377" height="80"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="여행 국가" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ORu-RI-UHw">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="20"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="20" id="xCH-qR-0Sj"/>
                                                                         </constraints>
@@ -601,13 +603,13 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="VbH-Nw-FCW">
-                                                                        <rect key="frame" x="0.0" y="30" width="374" height="50"/>
+                                                                        <rect key="frame" x="0.0" y="30" width="377" height="50"/>
                                                                         <subviews>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="br8-Kr-KgJ">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="75" height="50"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="75.5" height="50"/>
                                                                             </imageView>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hx8-N1-4lt" userLabel="국가명">
-                                                                                <rect key="frame" x="85" y="0.0" width="289" height="50"/>
+                                                                                <rect key="frame" x="85.5" y="0.0" width="291.5" height="50"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                 <color key="textColor" name="basicBlackTextColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -619,11 +621,11 @@
                                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="80" id="Cdn-ky-ahP"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ION-D8-hDv">
-                                                                <rect key="frame" x="0.0" y="230" width="374" height="468"/>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ION-D8-hDv" userLabel="Date Stack View">
+                                                                <rect key="frame" x="0.0" y="230" width="377" height="468"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="여행 날짜" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j64-9J-1XL">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="20"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="20" id="CUa-Iz-HQE"/>
                                                                         </constraints>
@@ -632,7 +634,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="AFl-ru-sTM">
-                                                                        <rect key="frame" x="0.0" y="28" width="374" height="216"/>
+                                                                        <rect key="frame" x="0.0" y="28" width="377" height="216"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="시작일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m9t-4a-9gb">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="44.5" height="216"/>
@@ -644,7 +646,7 @@
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="vVk-Xq-TIH">
-                                                                                <rect key="frame" x="54.5" y="0.0" width="319.5" height="216"/>
+                                                                                <rect key="frame" x="54.5" y="0.0" width="322.5" height="216"/>
                                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <locale key="locale" localeIdentifier="ko_KR"/>
@@ -658,7 +660,7 @@
                                                                         </constraints>
                                                                     </stackView>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hxd-BH-ZlL">
-                                                                        <rect key="frame" x="0.0" y="252" width="374" height="216"/>
+                                                                        <rect key="frame" x="0.0" y="252" width="377" height="216"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="종료일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tze-CV-1hb">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="44.5" height="216"/>
@@ -670,7 +672,7 @@
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="ohT-8N-2VX">
-                                                                                <rect key="frame" x="54.5" y="0.0" width="319.5" height="216"/>
+                                                                                <rect key="frame" x="54.5" y="0.0" width="322.5" height="216"/>
                                                                                 <color key="tintColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <locale key="locale" localeIdentifier="ko_KR"/>
                                                                                 <connections>
@@ -687,17 +689,17 @@
                                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="80" id="DlF-7U-bzi"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QdN-nP-JPb">
-                                                                <rect key="frame" x="0.0" y="728" width="374" height="120"/>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QdN-nP-JPb" userLabel="Budget Stack View">
+                                                                <rect key="frame" x="0.0" y="728" width="377" height="120"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="화폐 &amp; 예산" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sOh-WB-sbh">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="23.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="377" height="23.5"/>
                                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nO0-vp-HmP">
-                                                                        <rect key="frame" x="0.0" y="33.5" width="374" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="33.5" width="377" height="20.5"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KRW" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fe3-bv-cx8">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="37.5" height="20.5"/>
@@ -706,7 +708,7 @@
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="₩ 40,000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="84d-sc-2bv">
-                                                                                <rect key="frame" x="37.5" y="0.0" width="336.5" height="20.5"/>
+                                                                                <rect key="frame" x="37.5" y="0.0" width="339.5" height="20.5"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                                 <color key="textColor" name="basicBlackTextColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -717,7 +719,7 @@
                                                                         </constraints>
                                                                     </stackView>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qvF-Ok-csh" userLabel="BarBackground">
-                                                                        <rect key="frame" x="0.0" y="64" width="374" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="64" width="377" height="30"/>
                                                                         <subviews>
                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cgj-k5-VFd" userLabel="progress">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="30"/>
@@ -726,34 +728,35 @@
                                                                                     <constraint firstAttribute="width" constant="50" id="5UP-Wa-LVz"/>
                                                                                 </constraints>
                                                                             </view>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 %" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XiF-QM-NZR">
-                                                                                <rect key="frame" x="10" y="6" width="26" height="18"/>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 %" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XiF-QM-NZR">
+                                                                                <rect key="frame" x="9.5" y="6" width="358" height="18"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                         </subviews>
-                                                                        <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                         <constraints>
+                                                                            <constraint firstItem="XiF-QM-NZR" firstAttribute="width" secondItem="qvF-Ok-csh" secondAttribute="width" multiplier="0.95" id="2tp-xA-jbd"/>
                                                                             <constraint firstItem="Cgj-k5-VFd" firstAttribute="top" secondItem="qvF-Ok-csh" secondAttribute="top" id="Flf-h1-W0M"/>
                                                                             <constraint firstItem="XiF-QM-NZR" firstAttribute="centerY" secondItem="qvF-Ok-csh" secondAttribute="centerY" id="YBr-5F-AuR"/>
-                                                                            <constraint firstItem="XiF-QM-NZR" firstAttribute="leading" secondItem="qvF-Ok-csh" secondAttribute="leading" constant="10" id="ZzT-yJ-vUT"/>
                                                                             <constraint firstAttribute="height" constant="30" id="bfw-a6-6Jf"/>
+                                                                            <constraint firstItem="XiF-QM-NZR" firstAttribute="centerX" secondItem="qvF-Ok-csh" secondAttribute="centerX" id="jUJ-7j-CDb"/>
                                                                             <constraint firstItem="Cgj-k5-VFd" firstAttribute="leading" secondItem="qvF-Ok-csh" secondAttribute="leading" id="mDy-yk-O9O"/>
                                                                             <constraint firstAttribute="bottom" secondItem="Cgj-k5-VFd" secondAttribute="bottom" id="mOx-6V-Efg"/>
                                                                         </constraints>
                                                                     </view>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="je8-15-Loh">
-                                                                        <rect key="frame" x="0.0" y="104" width="374" height="16"/>
+                                                                        <rect key="frame" x="0.0" y="104" width="377" height="16"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="₩ 25,000 사용" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V5d-JZ-sid">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="185" height="16"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="188.5" height="16"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                                                                <color key="textColor" name="basicBlackTextColor"/>
+                                                                                <color key="textColor" name="basicGrayTextColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KRW 15,000 남음/₩ 23,000 초과" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rmn-Fr-kXg">
-                                                                                <rect key="frame" x="185" y="0.0" width="189" height="16"/>
+                                                                                <rect key="frame" x="188.5" y="0.0" width="188.5" height="16"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" name="basicBlackTextColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -768,17 +771,17 @@
                                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="120" id="37z-Zb-BRO"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mLF-Za-3WI">
-                                                                <rect key="frame" x="0.0" y="878" width="374" height="414"/>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mLF-Za-3WI" userLabel="Cover Stack View">
+                                                                <rect key="frame" x="0.0" y="878" width="377" height="417"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="커버 사진" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wi0-bO-BCq">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="377" height="30"/>
                                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <imageView clipsSubviews="YES" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WT6-i3-eZ8">
-                                                                        <rect key="frame" x="0.0" y="40" width="374" height="374"/>
+                                                                        <rect key="frame" x="0.0" y="40" width="377" height="377"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" secondItem="WT6-i3-eZ8" secondAttribute="height" multiplier="1:1" id="wsP-YL-vv2"/>
                                                                         </constraints>
@@ -786,10 +789,10 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eHl-w2-LWW" userLabel="Button View">
-                                                                <rect key="frame" x="0.0" y="1322" width="374" height="37.5"/>
+                                                                <rect key="frame" x="0.0" y="1325" width="377" height="37.5"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIM-lz-bbD" userLabel="여행 삭제하기">
-                                                                        <rect key="frame" x="131" y="0.0" width="112" height="37.5"/>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIM-lz-bbD" userLabel="여행 삭제하기">
+                                                                        <rect key="frame" x="132" y="0.0" width="113" height="37.5"/>
                                                                         <color key="backgroundColor" name="deleteButtonColor"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                         <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
@@ -806,7 +809,7 @@
                                                                         </connections>
                                                                     </button>
                                                                 </subviews>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <constraints>
                                                                     <constraint firstItem="eIM-lz-bbD" firstAttribute="top" secondItem="eHl-w2-LWW" secondAttribute="top" id="GmL-Jd-PP6"/>
                                                                     <constraint firstAttribute="width" secondItem="eHl-w2-LWW" secondAttribute="height" multiplier="10:1" id="MIb-du-ecy"/>
@@ -824,7 +827,7 @@
                                                         </constraints>
                                                     </stackView>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="bottom" secondItem="Ma0-RF-0Rk" secondAttribute="bottom" constant="20" id="0mA-rw-gX3"/>
                                                     <constraint firstItem="Ma0-RF-0Rk" firstAttribute="leading" secondItem="6aw-iA-A5G" secondAttribute="leading" constant="20" id="6Zs-hF-1E0"/>
@@ -841,7 +844,7 @@
                                         </constraints>
                                     </scrollView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="ux4-FQ-XbC" firstAttribute="leading" secondItem="YI3-ni-eQX" secondAttribute="leading" id="4ab-jw-mb0"/>
                                     <constraint firstAttribute="trailing" secondItem="6aw-iA-A5G" secondAttribute="trailing" id="BRO-JO-oy2"/>
@@ -851,14 +854,14 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="GL9-dr-PWQ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="YI3-ni-eQX" firstAttribute="top" secondItem="GL9-dr-PWQ" secondAttribute="top" id="Z2W-2W-yeL"/>
                             <constraint firstItem="GL9-dr-PWQ" firstAttribute="trailing" secondItem="YI3-ni-eQX" secondAttribute="trailing" id="ZjF-4e-1c4"/>
                             <constraint firstItem="YI3-ni-eQX" firstAttribute="leading" secondItem="GL9-dr-PWQ" secondAttribute="leading" id="epO-JR-yDD"/>
                             <constraint firstItem="GL9-dr-PWQ" firstAttribute="bottom" secondItem="YI3-ni-eQX" secondAttribute="bottom" id="ysR-Y0-u4J"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="GL9-dr-PWQ"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="여행프로필" image="airplane" catalog="system" id="Ln5-3b-m3G"/>
                     <connections>
@@ -869,6 +872,7 @@
                         <outlet property="endDatePicker" destination="ohT-8N-2VX" id="eFV-Vz-IIv"/>
                         <outlet property="expenseLabel" destination="V5d-JZ-sid" id="luk-Pv-2Mi"/>
                         <outlet property="flagImage" destination="br8-Kr-KgJ" id="Cut-Bt-1yB"/>
+                        <outlet property="progressBar" destination="Cgj-k5-VFd" id="kyk-Kw-VDB"/>
                         <outlet property="progressBarBackground" destination="qvF-Ok-csh" id="OaP-V9-s94"/>
                         <outlet property="progressBarWidthConstraint" destination="5UP-Wa-LVz" id="Pmt-RA-NdG"/>
                         <outlet property="progressPercentageLabel" destination="XiF-QM-NZR" id="5cz-4l-KY2"/>
@@ -921,7 +925,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="EUc-EQ-1Pe">
                                                     <rect key="frame" x="0.0" y="109" width="374" height="70"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vt1-wB-b2C">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vt1-wB-b2C">
                                                             <rect key="frame" x="0.0" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <state key="normal" title="취소">
@@ -931,7 +935,7 @@
                                                                 <action selector="cancelButtonTapped:" destination="oiW-sK-s0f" eventType="touchUpInside" id="g3E-wQ-axe"/>
                                                             </connections>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ha6-Yg-38H">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ha6-Yg-38H">
                                                             <rect key="frame" x="187" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <state key="normal" title="완료">
@@ -952,7 +956,7 @@
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstItem="Xft-Lx-5eQ" firstAttribute="top" secondItem="h3p-Pl-e1l" secondAttribute="top" constant="20" id="EDw-D1-zt1"/>
                                                 <constraint firstAttribute="bottom" secondItem="EUc-EQ-1Pe" secondAttribute="bottom" id="Nfh-nV-TtX"/>
@@ -978,7 +982,8 @@
                                 <blurEffect style="dark"/>
                             </visualEffectView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="TZg-A5-mcJ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="ufc-1i-Y1E" firstAttribute="top" secondItem="Giw-yE-nho" secondAttribute="top" id="32L-jQ-E88"/>
                             <constraint firstItem="h3p-Pl-e1l" firstAttribute="height" secondItem="Giw-yE-nho" secondAttribute="height" multiplier="0.2" id="Hpq-L1-ir2"/>
@@ -986,7 +991,6 @@
                             <constraint firstItem="ufc-1i-Y1E" firstAttribute="leading" secondItem="Giw-yE-nho" secondAttribute="leading" id="ZbB-hu-HEa"/>
                             <constraint firstAttribute="bottom" secondItem="ufc-1i-Y1E" secondAttribute="bottom" id="xc4-ZR-xYy"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="TZg-A5-mcJ"/>
                     </view>
                     <connections>
                         <outlet property="titleTextField" destination="Xft-Lx-5eQ" id="NDF-qG-jZ7"/>
@@ -1006,7 +1010,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020년 11월 17일 4:08:51" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ImO-lf-XQ3">
-                                <rect key="frame" x="123" y="59" width="168.5" height="18"/>
+                                <rect key="frame" x="123" y="59" width="168" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -1024,7 +1028,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="US$ 7.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4wV-KP-wum">
-                                                <rect key="frame" x="154" y="61.5" width="106.5" height="30"/>
+                                                <rect key="frame" x="154.5" y="61.5" width="105.5" height="30"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
                                                 <color key="textColor" name="deleteButtonColor"/>
                                                 <nil key="highlightedColor"/>
@@ -1037,7 +1041,7 @@
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Ar-ih-n1d" userLabel="seperator">
                                                 <rect key="frame" x="20" y="132.5" width="374" height="1"/>
-                                                <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Fdc-go-kXJ"/>
                                                 </constraints>
@@ -1098,13 +1102,13 @@
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="예산명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yxl-gY-oUx">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="339" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="339.5" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USD" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EdU-9L-4nm">
-                                                                        <rect key="frame" x="339" y="0.0" width="35" height="20.5"/>
+                                                                        <rect key="frame" x="339.5" y="0.0" width="34.5" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
@@ -1115,13 +1119,13 @@
                                                                 <rect key="frame" x="0.0" y="28.5" width="374" height="20.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="환율" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LBI-bm-1g8">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="199.5" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="201" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USD 1.00 = KRW 1,096" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Khp-bb-Ych">
-                                                                        <rect key="frame" x="199.5" y="0.0" width="174.5" height="20.5"/>
+                                                                        <rect key="frame" x="201" y="0.0" width="173" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
@@ -1141,7 +1145,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="uOJ-NV-xEH" userLabel="Button Stack View">
                                                 <rect key="frame" x="124" y="776.5" width="166" height="81"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Qv-Go-eCZ">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Qv-Go-eCZ">
                                                         <rect key="frame" x="0.0" y="0.0" width="166" height="38"/>
                                                         <color key="backgroundColor" name="lightMainColor"/>
                                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="0.0" maxY="10"/>
@@ -1157,7 +1161,7 @@
                                                             <action selector="editButtonTapped:" destination="n0l-Qt-t7z" eventType="touchUpInside" id="leZ-S8-6gh"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6DE-yh-NZb">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6DE-yh-NZb">
                                                         <rect key="frame" x="0.0" y="43" width="166" height="38"/>
                                                         <color key="backgroundColor" name="deleteButtonColor"/>
                                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="0.0" maxY="10"/>
@@ -1176,7 +1180,7 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="4wV-KP-wum" firstAttribute="top" secondItem="3iv-Zv-NJB" secondAttribute="bottom" constant="10" id="5zx-Mf-QXy"/>
                                             <constraint firstItem="4wV-KP-wum" firstAttribute="centerX" secondItem="p69-4J-mh8" secondAttribute="centerX" id="6Kw-9G-1Re"/>
@@ -1209,7 +1213,7 @@
                                     <constraint firstAttribute="trailing" secondItem="p69-4J-mh8" secondAttribute="trailing" id="irl-UI-GqD"/>
                                 </constraints>
                             </scrollView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eHk-JU-XwN">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eHk-JU-XwN">
                                 <rect key="frame" x="0.0" y="821" width="414" height="41"/>
                                 <color key="backgroundColor" name="mainColor"/>
                                 <state key="normal" title="닫기">
@@ -1224,7 +1228,8 @@
                                 <color key="backgroundColor" name="mainColor"/>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="qNU-nu-0oe"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="qNU-nu-0oe" firstAttribute="bottom" secondItem="eHk-JU-XwN" secondAttribute="bottom" id="1Qx-0Q-w66"/>
                             <constraint firstItem="nEJ-zQ-SvF" firstAttribute="top" secondItem="ImO-lf-XQ3" secondAttribute="bottom" constant="20" id="APM-Je-8rx"/>
@@ -1243,7 +1248,6 @@
                             <constraint firstItem="eHk-JU-XwN" firstAttribute="leading" secondItem="qNU-nu-0oe" secondAttribute="leading" id="wzq-CE-hr4"/>
                             <constraint firstItem="qNU-nu-0oe" firstAttribute="trailing" secondItem="eHk-JU-XwN" secondAttribute="trailing" id="zc8-mA-Vls"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="qNU-nu-0oe"/>
                     </view>
                     <connections>
                         <outlet property="amountLabel" destination="4wV-KP-wum" id="ZlA-ef-kD6"/>
@@ -1269,7 +1273,7 @@
     </scenes>
     <resources>
         <image name="airplane" catalog="system" width="128" height="115"/>
-        <image name="chart.pie.fill" catalog="system" width="128" height="124"/>
+        <image name="chart.pie.fill" catalog="system" width="128" height="121"/>
         <image name="historyImage" width="512" height="512"/>
         <image name="isPrepareFalse" width="64" height="64"/>
         <image name="list.bullet" catalog="system" width="128" height="88"/>
@@ -1299,5 +1303,17 @@
         <namedColor name="mainColor">
             <color red="0.46299999952316284" green="0.69800001382827759" blue="0.89800000190734863" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
### Issue Number
Close #218

### 변경사항
- 퍼센트 출력 시, int 범위를 초과하면 음수로 나오는 문제 해결 -> long
  long 으로 변경
- 퍼센트 레이블이 길어질 것을 대비하여  constraints 수정

### 새로운 기능
- 예산을 초과할 시, 초과 텍스트 색상 및 progress bar 색상 바뀌도록 함
- progress bar 의 corner radius 설정

<img width="502" alt="스크린샷 2020-12-10 오후 6 23 12" src="https://user-images.githubusercontent.com/28432479/101752422-d68ece80-3b14-11eb-8b16-f95a560a46c6.png">

### 작업 유형
- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
