### PR TITLE
레이블 범위 초과 오류 수정, NaN 에러처리

### DIFF
--- a/BoostPocket/BoostPocket/CustomView/PaddedLabel.swift
+++ b/BoostPocket/BoostPocket/CustomView/PaddedLabel.swift
@@ -23,7 +23,7 @@ class PaddedLabel: UILabel {
     func configure() {
         self.layer.borderWidth = 1
         self.layer.borderColor = UIColor.white.cgColor
-        self.layer.cornerRadius = self.frame.width * 0.2
+        self.layer.cornerRadius = self.frame.height * 0.5
     }
     
     // MARK: - Properties
@@ -34,9 +34,10 @@ class PaddedLabel: UILabel {
         return CGSize(width: width, height: heigth)
     }
     
+    // MARK: - Padding
+    
     private var padding: CGSize = .init(width: 0, height: 0)
     
-    // MARK: Padding
     @IBInspectable var paddingWidth: CGFloat {
         get { padding.width }
         set { padding.width = newValue }

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.swift
@@ -338,6 +338,12 @@ extension AddHistoryViewController {
             calculatorExpressionLabel.text?.removeLast()
         }
         
+        if calculatorExpressionLabel.text?.count == 1,
+            let lastCharacter = calculatorExpressionLabel.text?.last,
+            lastCharacter == "0" {
+            calculatorExpressionLabel.text?.removeLast()
+        }
+        
         calculatorExpressionLabel.text! += buttonText
         
         if buttonText != "." {
@@ -363,11 +369,18 @@ extension AddHistoryViewController {
             !lastCharacter.isOperation() {
             changeCalculatedAmountLabel()
         } else if calculatorExpressionLabel.text?.count == 0 {
-            calculatorExpressionLabel.text = "0"
-            calculatedAmountLabel.text = "0"
-            currencyConvertedAmountLabel.text = "KRW"
-            changeCalculatedAmountLabel()
+            initializeLabels()
+        } else if calculatorExpressionLabel.text?.count == 1,
+            let isOperation = calculatorExpressionLabel.text?.last?.isOperation(), isOperation {
+            initializeLabels()
         }
+    }
+    
+    private func initializeLabels() {
+        calculatorExpressionLabel.text = "0"
+        calculatedAmountLabel.text = "0"
+        currencyConvertedAmountLabel.text = "KRW"
+        changeCalculatedAmountLabel()
     }
     
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/HistoryCell.xib
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/HistoryCell.xib
@@ -23,8 +23,8 @@
                             <constraint firstAttribute="width" secondItem="NFJ-ir-T7d" secondAttribute="height" multiplier="1:1" id="TqG-Ut-15A"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pF6-0v-9CD">
-                        <rect key="frame" x="117" y="21" width="44" height="21"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pF6-0v-9CD">
+                        <rect key="frame" x="117" y="21" width="263" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                         <color key="textColor" name="mainColor"/>
                         <nil key="highlightedColor"/>
@@ -35,7 +35,7 @@
                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gU8-NF-FGt">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gU8-NF-FGt">
                         <rect key="frame" x="370" y="38" width="31" height="14.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <color key="textColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -46,6 +46,7 @@
                     <constraint firstAttribute="trailingMargin" secondItem="gU8-NF-FGt" secondAttribute="trailing" constant="10" id="5TW-UC-wUd"/>
                     <constraint firstItem="NFJ-ir-T7d" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="GXo-Eq-f1u"/>
                     <constraint firstItem="pF6-0v-9CD" firstAttribute="leading" secondItem="NFJ-ir-T7d" secondAttribute="trailing" constant="60" id="Hsz-6m-YgL"/>
+                    <constraint firstItem="pF6-0v-9CD" firstAttribute="trailing" secondItem="gU8-NF-FGt" secondAttribute="leading" constant="10" id="IRr-Yr-RJb"/>
                     <constraint firstItem="NFJ-ir-T7d" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="30" id="Lh0-84-JKg"/>
                     <constraint firstItem="Rkm-Sy-yRT" firstAttribute="leading" secondItem="pF6-0v-9CD" secondAttribute="leading" id="ga9-qb-AbM"/>
                     <constraint firstItem="gU8-NF-FGt" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="jOL-az-dwY"/>

--- a/BoostPocket/BoostPocket/TravelDetailScene/ReportScene/ReportPieChartView.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/ReportScene/ReportPieChartView.swift
@@ -115,6 +115,7 @@ class ReportPieChartView: UIView {
         addSubview(label)
         
         let roundedPercentage = round(slice.percent * 1000) / 10
+        
         label.text = roundedPercentage < 5 ? "" : String(format: "%.1f%%", roundedPercentage)
           
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/BoostPocket/BoostPocket/TravelDetailScene/ReportScene/ReportViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/ReportScene/ReportViewController.swift
@@ -122,7 +122,13 @@ class ReportViewController: UIViewController {
         var slices: [Slice] = []
         
         sortedAmounts.forEach { (category, amount) in
-            slices.append(Slice(category: category, percent: CGFloat(Float(amount) / Float(totalAmount))))
+            var percentage: CGFloat
+            if amount.isNaN || amount.isInfinite {
+                percentage = 1
+            } else {
+                percentage = CGFloat(amount / totalAmount)
+            }
+            slices.append(Slice(category: category, percent: percentage))
         }
         
         return slices

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
@@ -270,8 +270,8 @@
                             <constraint firstItem="gwU-vf-3l1" firstAttribute="trailing" secondItem="Z3N-xh-feq" secondAttribute="trailing" id="lBy-LH-pwj"/>
                             <constraint firstItem="TlZ-ef-Dwf" firstAttribute="width" secondItem="gwU-vf-3l1" secondAttribute="width" multiplier="2/7" id="lbN-Wz-cmH"/>
                             <constraint firstItem="TlZ-ef-Dwf" firstAttribute="leading" secondItem="gwU-vf-3l1" secondAttribute="leading" id="le0-lN-HEI"/>
-                            <constraint firstItem="Ymo-4K-Sav" firstAttribute="centerY" secondItem="oSf-dj-s8a" secondAttribute="centerY" id="pRh-vf-ufV"/>
                             <constraint firstItem="ALI-AJ-0ck" firstAttribute="centerY" secondItem="TlZ-ef-Dwf" secondAttribute="centerY" id="llR-96-pC3"/>
+                            <constraint firstItem="Ymo-4K-Sav" firstAttribute="centerY" secondItem="oSf-dj-s8a" secondAttribute="centerY" id="pRh-vf-ufV"/>
                             <constraint firstItem="ALI-AJ-0ck" firstAttribute="height" secondItem="TlZ-ef-Dwf" secondAttribute="height" multiplier="0.8" id="qGQ-K3-9Qh"/>
                             <constraint firstItem="jDJ-DO-0v7" firstAttribute="leading" secondItem="gwU-vf-3l1" secondAttribute="leading" id="qWB-nK-D1U"/>
                             <constraint firstItem="HQY-uN-Bt6" firstAttribute="width" secondItem="oSf-dj-s8a" secondAttribute="width" multiplier="0.98" priority="750" id="uHS-Xz-AaB"/>

--- a/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelItemViewModel.swift
@@ -52,7 +52,18 @@ class TravelItemViewModel: TravelItemPresentable, Equatable, Hashable {
     var expensePercentage: Float {
         let expenses = getTotalExpense()
         let incomes = getTotalIncome()
-        return incomes == 0 ? 0 : Float(expenses / incomes)
+        
+        var percentage: Float
+        
+        if expenses.isInfinite || expenses.isNaN {
+            percentage = 1
+        } else if incomes.isInfinite || expenses.isNaN {
+            percentage = 0
+        } else {
+            percentage = incomes == 0 ? 0 : Float(expenses / incomes)
+        }
+        
+        return percentage
     }
     
     var mostFrequentCategory: (HistoryCategory, Double) {
@@ -60,9 +71,17 @@ class TravelItemViewModel: TravelItemPresentable, Equatable, Hashable {
         
         let expenses = histories.filter { !$0.isIncome }
         let amounts = getHistoriesDictionary(from: expenses)
+        let totalExpense = getTotalExpense()
         
         if let (category, amount) = amounts.max(by: {$0.1 < $1.1}) {
-            let percentage = amount / getTotalExpense()
+            var percentage: Double
+            
+            if amount.isInfinite || amount.isNaN {
+                percentage = 1
+            } else {
+                percentage = amount / totalExpense
+            }
+
             return (category, round(percentage * 1000) / 10)
         }
         

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelCell.xib
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelCell.xib
@@ -33,7 +33,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="woF-dC-F93" customClass="PaddedLabel" customModule="BoostPocket" customModuleProvider="target">
-                        <rect key="frame" x="116.5" y="115.5" width="42" height="20.5"/>
+                        <rect key="frame" x="5" y="115.5" width="265" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
@@ -57,6 +57,8 @@
             <constraints>
                 <constraint firstItem="69T-Nt-sjr" firstAttribute="centerY" secondItem="Gmy-dG-DoZ" secondAttribute="bottom" multiplier="1/4" id="12p-AP-dcN"/>
                 <constraint firstItem="BvG-Ku-dp3" firstAttribute="top" relation="greaterThanOrEqual" secondItem="1sc-j4-zb5" secondAttribute="bottom" constant="2" id="15i-J4-rW8"/>
+                <constraint firstItem="woF-dC-F93" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="5" id="1bH-mX-zDM"/>
+                <constraint firstAttribute="trailing" secondItem="woF-dC-F93" secondAttribute="trailing" constant="5" id="35I-Pg-xCr"/>
                 <constraint firstAttribute="bottom" secondItem="Gmy-dG-DoZ" secondAttribute="bottom" id="BUB-N8-k3O"/>
                 <constraint firstAttribute="trailing" secondItem="Gmy-dG-DoZ" secondAttribute="trailing" id="FQx-sK-VBG"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="woF-dC-F93" secondAttribute="bottom" constant="5" id="JEp-k9-fdo"/>

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelHeaderCell.xib
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelHeaderCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,12 +20,12 @@
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <viewLayoutGuide key="safeArea" id="VXr-Tz-HHm"/>
             <constraints>
                 <constraint firstItem="dg6-B3-Hrv" firstAttribute="centerX" secondItem="VXr-Tz-HHm" secondAttribute="centerX" id="MR5-Aq-I0v"/>
                 <constraint firstItem="dg6-B3-Hrv" firstAttribute="centerY" secondItem="U6b-Vx-4bR" secondAttribute="centerY" id="irg-hA-cuu"/>
                 <constraint firstItem="dg6-B3-Hrv" firstAttribute="width" secondItem="VXr-Tz-HHm" secondAttribute="width" multiplier="0.9" id="liy-XT-uRe"/>
             </constraints>
+            <viewLayoutGuide key="safeArea" id="VXr-Tz-HHm"/>
             <connections>
                 <outlet property="headerLabel" destination="dg6-B3-Hrv" id="6hn-Gx-eGg"/>
             </connections>


### PR DESCRIPTION
### Issue Number
Close #217 

### 변경사항
- 여행목록화면의 여행 셀 - 총 지출 레이블
- 지출목록화면의 지출 셀 - 금액 레이블
- 리포트 화면의 information view, stack view의 금액 레이블
- 분자/분모가 각각 infinite/NaN일 경우 에러처리

### 새로운 기능
금액 레이블이 다른 뷰의 영역을 침범하지 않는다.
NaN일 정도로 금액이 커도 에러처리를 할 수 있다.

### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
