### PR TITLE
TravelProfile 테스트 및 구조 변경

### DIFF
--- a/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
+++ b/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		95AC159C2585D0770079F042 /* HistoryListVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AC159B2585D0770079F042 /* HistoryListVCTests.swift */; };
 		95AC159E2585ED5D0079F042 /* HistoryListSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AC159D2585ED5D0079F042 /* HistoryListSupport.swift */; };
 		95AC15A02585EDE30079F042 /* TravelListSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AC159F2585EDE30079F042 /* TravelListSupport.swift */; };
+		95AC15A22585F2C20079F042 /* TravelProfileVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AC15A12585F2C20079F042 /* TravelProfileVCTests.swift */; };
 		95C8F4BE258301E500B8D91E /* Date+isValidInRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C8F4BD258301E500B8D91E /* Date+isValidInRange.swift */; };
 		95F8A29C2580C9B800A33D3E /* ExpenseElementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F8A29B2580C9B800A33D3E /* ExpenseElementView.swift */; };
 		95F8A29E2580C9CE00A33D3E /* ExpenseElementView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 95F8A29D2580C9CE00A33D3E /* ExpenseElementView.xib */; };
@@ -234,6 +235,7 @@
 		95AC159B2585D0770079F042 /* HistoryListVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListVCTests.swift; sourceTree = "<group>"; };
 		95AC159D2585ED5D0079F042 /* HistoryListSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListSupport.swift; sourceTree = "<group>"; };
 		95AC159F2585EDE30079F042 /* TravelListSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListSupport.swift; sourceTree = "<group>"; };
+		95AC15A12585F2C20079F042 /* TravelProfileVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelProfileVCTests.swift; sourceTree = "<group>"; };
 		95C8F4BD258301E500B8D91E /* Date+isValidInRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+isValidInRange.swift"; sourceTree = "<group>"; };
 		95F8A29B2580C9B800A33D3E /* ExpenseElementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseElementView.swift; sourceTree = "<group>"; };
 		95F8A29D2580C9CE00A33D3E /* ExpenseElementView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ExpenseElementView.xib; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				95A42E9525664DC40007810C /* Info.plist */,
 				950743B02583CEA700B2A992 /* TravelListVCTests.swift */,
 				95AC159B2585D0770079F042 /* HistoryListVCTests.swift */,
+				95AC15A12585F2C20079F042 /* TravelProfileVCTests.swift */,
 			);
 			path = BoostPocketTests;
 			sourceTree = "<group>";
@@ -1010,6 +1013,7 @@
 				5C96E8E2256BDA4200246590 /* CountryViewModelTests.swift in Sources */,
 				5C8C91AD256E8F0F008C3919 /* TravelViewModelTests.swift in Sources */,
 				9572F9B3256B974C003049CB /* PersistenceManagerStub.swift in Sources */,
+				95AC15A22585F2C20079F042 /* TravelProfileVCTests.swift in Sources */,
 				A99E065425778B130014C29F /* HistoryViewModelTests.swift in Sources */,
 				5C89619E256E917300575677 /* TravelStub.swift in Sources */,
 				A99E064C257773430014C29F /* HistoryProviderTests.swift in Sources */,

--- a/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
+++ b/BoostPocket/BoostPocket.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		95A42E8925664DC40007810C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95A42E8725664DC40007810C /* LaunchScreen.storyboard */; };
 		95A42E9425664DC40007810C /* BoostPocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A42E9325664DC40007810C /* BoostPocketTests.swift */; };
 		95AC159C2585D0770079F042 /* HistoryListVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AC159B2585D0770079F042 /* HistoryListVCTests.swift */; };
+		95AC159E2585ED5D0079F042 /* HistoryListSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AC159D2585ED5D0079F042 /* HistoryListSupport.swift */; };
+		95AC15A02585EDE30079F042 /* TravelListSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AC159F2585EDE30079F042 /* TravelListSupport.swift */; };
 		95C8F4BE258301E500B8D91E /* Date+isValidInRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C8F4BD258301E500B8D91E /* Date+isValidInRange.swift */; };
 		95F8A29C2580C9B800A33D3E /* ExpenseElementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F8A29B2580C9B800A33D3E /* ExpenseElementView.swift */; };
 		95F8A29E2580C9CE00A33D3E /* ExpenseElementView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 95F8A29D2580C9CE00A33D3E /* ExpenseElementView.xib */; };
@@ -230,6 +232,8 @@
 		95A42E9325664DC40007810C /* BoostPocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoostPocketTests.swift; sourceTree = "<group>"; };
 		95A42E9525664DC40007810C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		95AC159B2585D0770079F042 /* HistoryListVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListVCTests.swift; sourceTree = "<group>"; };
+		95AC159D2585ED5D0079F042 /* HistoryListSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListSupport.swift; sourceTree = "<group>"; };
+		95AC159F2585EDE30079F042 /* TravelListSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListSupport.swift; sourceTree = "<group>"; };
 		95C8F4BD258301E500B8D91E /* Date+isValidInRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+isValidInRange.swift"; sourceTree = "<group>"; };
 		95F8A29B2580C9B800A33D3E /* ExpenseElementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseElementView.swift; sourceTree = "<group>"; };
 		95F8A29D2580C9CE00A33D3E /* ExpenseElementView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ExpenseElementView.xib; sourceTree = "<group>"; };
@@ -338,6 +342,7 @@
 			children = (
 				A980ADC6257095E60001F5DC /* View */,
 				A9BF7A4F256E293F00496CD8 /* TravelProvider.swift */,
+				95AC159F2585EDE30079F042 /* TravelListSupport.swift */,
 				954F7018256D1C4B00B2E48B /* TravelListViewModel.swift */,
 				5C8C9195256E8436008C3919 /* TravelItemViewModel.swift */,
 			);
@@ -549,6 +554,7 @@
 			children = (
 				A99E06A8258062710014C29F /* View */,
 				A99E0638257763B90014C29F /* HistoryProvider.swift */,
+				95AC159D2585ED5D0079F042 /* HistoryListSupport.swift */,
 				A99E0645257766F50014C29F /* HistoryItemViewModel.swift */,
 				5C7F8372257902A000A58112 /* HistoryListSectionHeader.swift */,
 				5CD9A894257DCA2300A7AEFF /* HistoryFilter.swift */,
@@ -969,11 +975,13 @@
 				A99E062F257762520014C29F /* History+CoreDataClass.swift in Sources */,
 				5C7F8373257902A100A58112 /* HistoryListSectionHeader.swift in Sources */,
 				950BE471257F793200ACC0CA /* String+IsCategory.swift in Sources */,
+				95AC15A02585EDE30079F042 /* TravelListSupport.swift in Sources */,
 				5C15AB492577DED700244C6C /* HistoryHeaderCell.swift in Sources */,
 				9572F9AE256B9524003049CB /* CountryProvider.swift in Sources */,
 				5CD76EBF256C938D00BD6CE3 /* BoostPocket.xcdatamodeld in Sources */,
 				950BE473257F7C7B00ACC0CA /* String+IsPlaceholder.swift in Sources */,
 				95A42E7A25664DBE0007810C /* AppDelegate.swift in Sources */,
+				95AC159E2585ED5D0079F042 /* HistoryListSupport.swift in Sources */,
 				5C15AB3E2577C32000244C6C /* HistoryCell.swift in Sources */,
 				5CE798C0257F7CDB00AC6C43 /* ReportViewController.swift in Sources */,
 				5CF409482575239200351F4B /* MemoEditViewController.swift in Sources */,

--- a/BoostPocket/BoostPocket/Models/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/Models/PersistenceManager.swift
@@ -141,6 +141,12 @@ extension PersistenceManager {
         
         if let newCountryInfo = newObjectInfo as? CountryInfo {
             createdObject = setupCountryInfo(countryInfo: newCountryInfo)
+            guard saveContext() else {
+                completion(nil)
+                return
+            }
+            
+            completion(createdObject)
         } else if let newTravelInfo = newObjectInfo as? TravelInfo {
             setupTravelInfo(travelInfo: newTravelInfo) { [weak self] newTravel in
                 createdObject = newTravel
@@ -149,7 +155,6 @@ extension PersistenceManager {
                     completion(nil)
                     return
                 }
-                
                 completion(createdObject)
             }
         } else if let newHistoryInfo = newObjectInfo as? HistoryInfo {

--- a/BoostPocket/BoostPocket/Models/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/Models/PersistenceManager.swift
@@ -26,7 +26,7 @@ protocol PersistenceManagable: AnyObject {
     func delete<T>(deletingObject: T) -> Bool
     func count<T: NSManagedObject>(request: NSFetchRequest<T>) -> Int?
     func setupTravelInfo(travelInfo: TravelInfo, completion: @escaping (Travel?) -> Void)
-    func saveContext()
+    @discardableResult func saveContext() -> Bool
 }
 
 class PersistenceManager: PersistenceManagable {
@@ -118,14 +118,18 @@ class PersistenceManager: PersistenceManagable {
 // MARK: - Core Data Saving support
 
 extension PersistenceManager {
-    func saveContext() {
+    @discardableResult
+    func saveContext() -> Bool {
         if context.hasChanges {
             do {
                 try context.save()
+                return true
             } catch let saveError {
                 print("saveContext 실패: \(saveError)")
+                return false
             }
         }
+        return true
     }
 }
 
@@ -137,17 +141,23 @@ extension PersistenceManager {
         
         if let newCountryInfo = newObjectInfo as? CountryInfo {
             createdObject = setupCountryInfo(countryInfo: newCountryInfo)
-            saveContext()
-            completion(createdObject)
         } else if let newTravelInfo = newObjectInfo as? TravelInfo {
-            setupTravelInfo(travelInfo: newTravelInfo) { [weak self] (newTravel) in
+            setupTravelInfo(travelInfo: newTravelInfo) { [weak self] newTravel in
                 createdObject = newTravel
-                self?.saveContext()
+                
+                guard let self = self, self.saveContext() else {
+                    completion(nil)
+                    return
+                }
+                
                 completion(createdObject)
             }
         } else if let newHistoryInfo = newObjectInfo as? HistoryInfo {
             createdObject = setupHistoryInfo(historyInfo: newHistoryInfo)
-            saveContext()
+            guard saveContext() else {
+                completion(nil)
+                return
+            }
             completion(createdObject)
         }
     }
@@ -221,7 +231,7 @@ extension PersistenceManager {
         newTravel.coverImage = travelInfo.coverImage
         
         if let lastUpdated = fetchedCountry.lastUpdated, isExchangeRateOutdated(lastUpdated: lastUpdated) {
-            dataLoader?.requestExchangeRate(url: exchangeRateAPIurl) { [weak self] (result) in
+            dataLoader?.requestExchangeRate(url: exchangeRateAPIurl) { [weak self] result in
                 guard let currencyCode = fetchedCountry.currencyCode else { return }
                 
                 switch result {
@@ -352,17 +362,20 @@ extension PersistenceManager {
         var updatedObject: DataModelProtocol?
         
         if let updatedTravelInfo = updatedObjectInfo as? TravelInfo,
-            let updatedTravel =  updateTravel(travelInfo: updatedTravelInfo) {
+            let updatedTravel = updateTravel(travelInfo: updatedTravelInfo) {
             updatedObject = updatedTravel
+            completion(updatedObject)
         } else if let updatedCountryInfo = updatedObjectInfo as? CountryInfo,
             let updatedCountry = updateCountry(countryInfo: updatedCountryInfo) {
             updatedObject = updatedCountry
+            completion(updatedObject)
         } else if let updatedHistoryInfo = updatedObjectInfo as? HistoryInfo,
             let updatedHistory = updateHistory(historyInfo: updatedHistoryInfo) {
             updatedObject = updatedHistory
+            completion(updatedObject)
+        } else {
+            completion(nil)
         }
-        
-        completion(updatedObject)
     }
 
     private func updateHistory(historyInfo: HistoryInfo) -> History? {
@@ -377,7 +390,7 @@ extension PersistenceManager {
         updatingHistory.memo = historyInfo.memo
         updatingHistory.title = historyInfo.title
         
-        saveContext()
+        guard saveContext() else { return nil }
         return updatingHistory
     }
     
@@ -390,7 +403,7 @@ extension PersistenceManager {
         updatingTravel.endDate = travelInfo.endDate
         updatingTravel.coverImage = travelInfo.coverImage
         
-        saveContext()
+        guard saveContext() else { return nil }
         return updatingTravel
     }
     
@@ -400,7 +413,7 @@ extension PersistenceManager {
         updatingCountry.lastUpdated = countryInfo.lastUpdated
         updatingCountry.exchangeRate = countryInfo.exchangeRate
 
-        saveContext()
+        guard saveContext() else { return nil }
         return updatingCountry
     }
 }
@@ -409,8 +422,7 @@ extension PersistenceManager {
 
 extension PersistenceManager {
     func delete<T>(deletingObject: T) -> Bool {
-        
-        if let travelObject = deletingObject as? Travel {
+        if let travelObject = deletingObject as? Travel, deleteHistories(of: travelObject) {
             self.context.delete(travelObject)
         } else if let countryObject = deletingObject as? Country {
             self.context.delete(countryObject)
@@ -418,13 +430,20 @@ extension PersistenceManager {
             self.context.delete(historyObject)
         }
         
-        do {
-            try context.save()
-            return true
-        } catch {
-            print(error.localizedDescription)
-            return false
+        guard saveContext() else { return false }
+        return true
+    }
+    
+    func deleteHistories(of travel: Travel) -> Bool {
+        let historySet = travel.mutableSetValue(forKey: "history")
+        
+        for history in historySet {
+            guard let historyObject = history as? NSManagedObject else { return false }
+            context.delete(historyObject)
         }
+        
+        guard saveContext() else { return false }
+        return true
     }
 }
 

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/HistoryListSupport.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/HistoryListSupport.swift
@@ -1,0 +1,23 @@
+//
+//  HistoryListSupport.swift
+//  BoostPocket
+//
+//  Created by sihyung you on 2020/12/13.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+import Foundation
+
+protocol HistoryListVCPresenter: AnyObject {
+    var onViewDidLoadCalled: Bool { get }
+    var onFloatingActionButtonTappedCalled: Bool { get }
+    var onCloseFloatingActionsCalled: Bool { get }
+    var onOpenFloatingActionsCalled: Bool { get }
+    var onRotateFloatingActionButtonCalled: Bool { get }
+    
+    func onViewDidLoad()
+    func onFloatingActionButtonTapped()
+    func onCloseFloatingActions()
+    func onOpenFloatingActions()
+    func onRotateFloatingActionButton()
+}

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/HistoryListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryListScene/View/HistoryListViewController.swift
@@ -14,20 +14,6 @@ class DataSource: UITableViewDiffableDataSource<HistoryListSectionHeader, Histor
     }
 }
 
-protocol HistoryListVCPresenter: AnyObject {
-    var onViewDidLoadCalled: Bool { get }
-    var onFloatingActionButtonTappedCalled: Bool { get }
-    var onCloseFloatingActionsCalled: Bool { get }
-    var onOpenFloatingActionsCalled: Bool { get }
-    var onRotateFloatingActionButtonCalled: Bool { get }
-    
-    func onViewDidLoad()
-    func onFloatingActionButtonTapped()
-    func onCloseFloatingActions()
-    func onOpenFloatingActions()
-    func onRotateFloatingActionButton()
-}
-
 class HistoryListViewController: UIViewController {
     static let identifier = "HistoryListViewController"
     
@@ -46,7 +32,6 @@ class HistoryListViewController: UIViewController {
     @IBOutlet weak var historyGuideLabel: UILabel!
     
     lazy var buttons = [self.addExpenseButton, self.addIncomeButton]
-    
     weak var presenter: HistoryListVCPresenter?
     weak var travelItemViewModel: HistoryListPresentable?
     private weak var selectedDateButton: UIButton?

--- a/BoostPocket/BoostPocket/TravelDetailScene/ProfileScene/TravelProfileViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/ProfileScene/TravelProfileViewController.swift
@@ -10,13 +10,25 @@ import UIKit
 
 protocol TravelProfileDelegate: AnyObject {
     func deleteTravel(id: UUID?)
-    func updateTravel(id: UUID?, newTitle: String?, newMemo: String?, newStartDate: Date?, newEndDate: Date?, newCoverImage: Data?, newBudget: Double?, newExchangeRate: Double?)
+    func updateTravel(id: UUID?, newTitle: String?, newMemo: String?, newStartDate: Date?, newEndDate: Date?, newCoverImage: Data?, newBudget: Double?, newExchangeRate: Double?, completion: @escaping (Bool) -> Void)
+}
+
+protocol TravelProfileVCPresenter: AnyObject {
+    var onViewDidLoadCalled: Bool { get }
+    var onMemoLabelTappedCalled: Bool { get }
+    var onStartDateSelectedCalled: Bool { get }
+    
+    func onViewDidLoad()
+    func onMemoLabelTapped()
+    func onStartDateSelected()
 }
 
 class TravelProfileViewController: UIViewController {
+    static let identifier = "TravelProfileViewController"
     // TODO: - private으로 감추고 주입하는 방법 생각해보기
     weak var travelItemViewModel: TravelItemPresentable?
     weak var profileDelegate: TravelProfileDelegate?
+    weak var presenter: TravelProfileVCPresenter?
     
     @IBOutlet weak var travelMemoLabel: UILabel!
     @IBOutlet weak var travelTitleLabel: UILabel!
@@ -48,6 +60,8 @@ class TravelProfileViewController: UIViewController {
         travelTitleLabel.addGestureRecognizer(titleTap)
         travelMemoLabel.addGestureRecognizer(memoTap)
         coverImage.addGestureRecognizer(coverImageTap)
+        
+        presenter?.onViewDidLoad()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -63,7 +77,7 @@ class TravelProfileViewController: UIViewController {
         
         progressBarWidthConstraint.constant = percentage > 1 ? progressBarBackground.frame.width : progressBarBackground.frame.width * CGFloat(percentage)
     }
-
+    
     private func setupTravelProfile() {
         guard let travelItemViewModel = travelItemViewModel else { return }
         travelTitleLabel.text = travelItemViewModel.title
@@ -108,26 +122,65 @@ class TravelProfileViewController: UIViewController {
     
     @IBAction func startDateSelected(_ sender: UIDatePicker) {
         endDatePicker.minimumDate = startDatePicker.date
-        profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: sender.date, newEndDate: endDatePicker?.date, newCoverImage: travelItemViewModel?.coverImage, newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate)
+        profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: sender.date, newEndDate: endDatePicker?.date, newCoverImage: travelItemViewModel?.coverImage, newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { result in
+            if result {
+                print("여행 시작일 업데이트 성공")
+            } else {
+                // TODO: - 실패 Alert
+                print("여행 종료일 업데이트 실패")
+            }
+        }
+        presenter?.onStartDateSelected()
     }
     
     @IBAction func endDateSelected(_ sender: UIDatePicker) {
         startDatePicker.maximumDate = endDatePicker.date
-        profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: startDatePicker.date, newEndDate: sender.date, newCoverImage: travelItemViewModel?.coverImage, newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate)
+        
+        profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: startDatePicker.date, newEndDate: sender.date, newCoverImage: travelItemViewModel?.coverImage, newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { result in
+            if result {
+                print("여행 종료일 업데이트 성공")
+            } else {
+                // TODO: - 실패 Alert
+                print("여행 종료일 업데이트 실패")
+            }
+        }
     }
     
     @objc func titleLabelTapped() {
         TitleEditViewController.present(at: self, previousTitle: travelTitleLabel.text ?? "") { [weak self] (newTitle) in
-            let updatingTitle = newTitle.isEmpty ? self?.travelItemViewModel?.countryName : newTitle
-            self?.travelTitleLabel.text = updatingTitle
-            self?.profileDelegate?.updateTravel(id: self?.travelItemViewModel?.id, newTitle: updatingTitle, newMemo: self?.travelItemViewModel?.memo, newStartDate: self?.travelItemViewModel?.startDate, newEndDate: self?.travelItemViewModel?.endDate, newCoverImage: self?.travelItemViewModel?.coverImage, newBudget: self?.travelItemViewModel?.budget, newExchangeRate: self?.travelItemViewModel?.exchangeRate)
+            guard let self = self else { return }
+            let updatingTitle = newTitle.isEmpty ? self.travelItemViewModel?.countryName : newTitle
+            
+            self.profileDelegate?.updateTravel(id: self.travelItemViewModel?.id, newTitle: updatingTitle, newMemo: self.travelItemViewModel?.memo, newStartDate: self.travelItemViewModel?.startDate, newEndDate: self.travelItemViewModel?.endDate, newCoverImage: self.travelItemViewModel?.coverImage, newBudget: self.travelItemViewModel?.budget, newExchangeRate: self.travelItemViewModel?.exchangeRate) { result in
+                if result {
+                    print("여행 타이틀 업데이트 성공")
+                    DispatchQueue.main.async {
+                        self.travelTitleLabel.text = updatingTitle
+                    }
+                } else {
+                    // TODO: - 실패 Alert
+                    print("여행 타이틀 업데이트 실패")
+                }
+            }
         }
     }
     
     @objc func memoLabelTapped() {
+        presenter?.onMemoLabelTapped()
         MemoEditViewController.present(at: self, memoType: .travelMemo, previousMemo: self.travelItemViewModel?.memo) { [weak self] (newMemo) in
-            self?.travelMemoLabel.text = newMemo.isEmpty ? "여행을 위한 메모를 입력해보세요" : newMemo
-            self?.profileDelegate?.updateTravel(id: self?.travelItemViewModel?.id, newTitle: self?.travelItemViewModel?.title, newMemo: newMemo, newStartDate: self?.travelItemViewModel?.startDate, newEndDate: self?.travelItemViewModel?.endDate, newCoverImage: self?.travelItemViewModel?.coverImage, newBudget: self?.travelItemViewModel?.budget, newExchangeRate: self?.travelItemViewModel?.exchangeRate)
+            let updatingMemo = newMemo.isEmpty ? EditMemoType.travelMemo.rawValue : newMemo
+
+            self?.profileDelegate?.updateTravel(id: self?.travelItemViewModel?.id, newTitle: self?.travelItemViewModel?.title, newMemo: updatingMemo, newStartDate: self?.travelItemViewModel?.startDate, newEndDate: self?.travelItemViewModel?.endDate, newCoverImage: self?.travelItemViewModel?.coverImage, newBudget: self?.travelItemViewModel?.budget, newExchangeRate: self?.travelItemViewModel?.exchangeRate) { result in
+                if result {
+                    print("여행 메모 업데이트 성공")
+                    DispatchQueue.main.async {
+                        self?.travelMemoLabel.text = updatingMemo
+                    }
+                } else {
+                    // TODO: - 실패 Alert
+                    print("여행 메모 업데이트 실패")
+                }
+            }
         }
     }
     
@@ -146,9 +199,17 @@ extension TravelProfileViewController: UIImagePickerControllerDelegate, UINaviga
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         
         if let newImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            coverImage.image = newImage
-            
-            profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: travelItemViewModel?.startDate, newEndDate: travelItemViewModel?.endDate, newCoverImage: newImage.pngData(), newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate)
+            profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: travelItemViewModel?.startDate, newEndDate: travelItemViewModel?.endDate, newCoverImage: newImage.pngData(), newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { [weak self ]result in
+                if result {
+                    print("여행 커버이미지 업데이트 성공")
+                    DispatchQueue.main.async {
+                        self?.coverImage.image = newImage
+                    }
+                } else {
+                    // TODO: - 실패 Alert
+                    print("여행 커버이미지 업데이트 실패")
+                }
+            }
         }
         dismiss(animated: true, completion: nil)
     }

--- a/BoostPocket/BoostPocket/TravelDetailScene/ProfileScene/TravelProfileViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/ProfileScene/TravelProfileViewController.swift
@@ -109,25 +109,22 @@ class TravelProfileViewController: UIViewController {
     }
     
     @IBAction func deleteButtonTapped(_ sender: UIButton) {
-        let alert = UIAlertController(title: "여행을 삭제하시겠습니까?", message: "저장된 여행 정보가 사라집니다.", preferredStyle: UIAlertController.Style.alert)
-        let okAction = UIAlertAction(title: "확인", style: .destructive) { _ in
-            self.profileDelegate?.deleteTravel(id: self.travelItemViewModel?.id)
-            self.navigationController?.popViewController(animated: true)
+        let okAction: (() -> Void)? = { [weak self] in
+            self?.profileDelegate?.deleteTravel(id: self?.travelItemViewModel?.id)
+            self?.navigationController?.popViewController(animated: true)
         }
-        let cancel = UIAlertAction(title: "취소", style: .default, handler: nil)
-        alert.addAction(cancel)
-        alert.addAction(okAction)
-        present(alert, animated: true, completion: nil)
+        
+        presentAlertView(title: "여행을 삭제하시겠습니까?", message: "저장된 여행 정보가 사라집니다.", okAction: okAction, isCancelButton: true)
     }
     
     @IBAction func startDateSelected(_ sender: UIDatePicker) {
         endDatePicker.minimumDate = startDatePicker.date
-        profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: sender.date, newEndDate: endDatePicker?.date, newCoverImage: travelItemViewModel?.coverImage, newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { result in
+        profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: sender.date, newEndDate: endDatePicker?.date, newCoverImage: travelItemViewModel?.coverImage, newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { [weak self] result in
             if result {
                 print("여행 시작일 업데이트 성공")
             } else {
-                // TODO: - 실패 Alert
                 print("여행 종료일 업데이트 실패")
+                self?.presentAlertView(title: "시작일 업데이트에 실패했습니다", message: "다시 시도해주세요", okAction: nil, isCancelButton: false)
             }
         }
         presenter?.onStartDateSelected()
@@ -136,12 +133,12 @@ class TravelProfileViewController: UIViewController {
     @IBAction func endDateSelected(_ sender: UIDatePicker) {
         startDatePicker.maximumDate = endDatePicker.date
         
-        profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: startDatePicker.date, newEndDate: sender.date, newCoverImage: travelItemViewModel?.coverImage, newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { result in
+        profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: startDatePicker.date, newEndDate: sender.date, newCoverImage: travelItemViewModel?.coverImage, newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { [weak self] result in
             if result {
                 print("여행 종료일 업데이트 성공")
             } else {
-                // TODO: - 실패 Alert
                 print("여행 종료일 업데이트 실패")
+                self?.presentAlertView(title: "종료일 업데이트에 실패했습니다", message: "다시 시도해주세요", okAction: nil, isCancelButton: false)
             }
         }
     }
@@ -151,15 +148,15 @@ class TravelProfileViewController: UIViewController {
             guard let self = self else { return }
             let updatingTitle = newTitle.isEmpty ? self.travelItemViewModel?.countryName : newTitle
             
-            self.profileDelegate?.updateTravel(id: self.travelItemViewModel?.id, newTitle: updatingTitle, newMemo: self.travelItemViewModel?.memo, newStartDate: self.travelItemViewModel?.startDate, newEndDate: self.travelItemViewModel?.endDate, newCoverImage: self.travelItemViewModel?.coverImage, newBudget: self.travelItemViewModel?.budget, newExchangeRate: self.travelItemViewModel?.exchangeRate) { result in
+            self.profileDelegate?.updateTravel(id: self.travelItemViewModel?.id, newTitle: updatingTitle, newMemo: self.travelItemViewModel?.memo, newStartDate: self.travelItemViewModel?.startDate, newEndDate: self.travelItemViewModel?.endDate, newCoverImage: self.travelItemViewModel?.coverImage, newBudget: self.travelItemViewModel?.budget, newExchangeRate: self.travelItemViewModel?.exchangeRate) { [weak self] result in
                 if result {
                     print("여행 타이틀 업데이트 성공")
                     DispatchQueue.main.async {
-                        self.travelTitleLabel.text = updatingTitle
+                        self?.travelTitleLabel.text = updatingTitle
                     }
                 } else {
-                    // TODO: - 실패 Alert
                     print("여행 타이틀 업데이트 실패")
+                    self?.presentAlertView(title: "제목 업데이트에 실패했습니다", message: "다시 시도해주세요", okAction: nil, isCancelButton: false)
                 }
             }
         }
@@ -170,15 +167,15 @@ class TravelProfileViewController: UIViewController {
         MemoEditViewController.present(at: self, memoType: .travelMemo, previousMemo: self.travelItemViewModel?.memo) { [weak self] (newMemo) in
             let updatingMemo = newMemo.isEmpty ? EditMemoType.travelMemo.rawValue : newMemo
 
-            self?.profileDelegate?.updateTravel(id: self?.travelItemViewModel?.id, newTitle: self?.travelItemViewModel?.title, newMemo: updatingMemo, newStartDate: self?.travelItemViewModel?.startDate, newEndDate: self?.travelItemViewModel?.endDate, newCoverImage: self?.travelItemViewModel?.coverImage, newBudget: self?.travelItemViewModel?.budget, newExchangeRate: self?.travelItemViewModel?.exchangeRate) { result in
+            self?.profileDelegate?.updateTravel(id: self?.travelItemViewModel?.id, newTitle: self?.travelItemViewModel?.title, newMemo: updatingMemo, newStartDate: self?.travelItemViewModel?.startDate, newEndDate: self?.travelItemViewModel?.endDate, newCoverImage: self?.travelItemViewModel?.coverImage, newBudget: self?.travelItemViewModel?.budget, newExchangeRate: self?.travelItemViewModel?.exchangeRate) { [weak self] result in
                 if result {
                     print("여행 메모 업데이트 성공")
                     DispatchQueue.main.async {
                         self?.travelMemoLabel.text = updatingMemo
                     }
                 } else {
-                    // TODO: - 실패 Alert
                     print("여행 메모 업데이트 실패")
+                    self?.presentAlertView(title: "메모 업데이트에 실패했습니다", message: "다시 시도해주세요", okAction: nil, isCancelButton: false)
                 }
             }
         }
@@ -199,18 +196,40 @@ extension TravelProfileViewController: UIImagePickerControllerDelegate, UINaviga
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         
         if let newImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: travelItemViewModel?.startDate, newEndDate: travelItemViewModel?.endDate, newCoverImage: newImage.pngData(), newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { [weak self ]result in
+            profileDelegate?.updateTravel(id: travelItemViewModel?.id, newTitle: travelItemViewModel?.title, newMemo: travelItemViewModel?.memo, newStartDate: travelItemViewModel?.startDate, newEndDate: travelItemViewModel?.endDate, newCoverImage: newImage.pngData(), newBudget: travelItemViewModel?.budget, newExchangeRate: travelItemViewModel?.exchangeRate) { [weak self] result in
                 if result {
                     print("여행 커버이미지 업데이트 성공")
                     DispatchQueue.main.async {
                         self?.coverImage.image = newImage
                     }
                 } else {
-                    // TODO: - 실패 Alert
                     print("여행 커버이미지 업데이트 실패")
+                    self?.presentAlertView(title: "커버사진 업데이트에 실패했습니다", message: "다시 시도해주세요", okAction: nil, isCancelButton: false)
                 }
             }
         }
         dismiss(animated: true, completion: nil)
+    }
+}
+
+extension TravelProfileViewController {
+    func presentAlertView(title: String,
+                          message: String,
+                          okAction: (() -> Void)?,
+                          isCancelButton: Bool) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertController.Style.alert)
+        
+        if isCancelButton {
+            let cancelAction = UIAlertAction(title: "취소", style: .default)
+            alert.addAction(cancelAction)
+        }
+        
+        let okAction = UIAlertAction(title: "확인", style: .destructive) { _ in
+            okAction?()
+        }
+        
+        alert.addAction(okAction)
+        
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
@@ -545,7 +545,7 @@
         <!--TravelProfile-->
         <scene sceneID="CCJ-Ny-tBe">
             <objects>
-                <viewController title="TravelProfile" id="F3d-DV-lrb" customClass="TravelProfileViewController" customModule="BoostPocket" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TravelProfileViewController" title="TravelProfile" id="F3d-DV-lrb" customClass="TravelProfileViewController" customModule="BoostPocket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ceG-Wu-6YY">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BoostPocket/BoostPocket/TravelListScene/TravelListSupport.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelListSupport.swift
@@ -20,10 +20,12 @@ protocol TravelListVCPresenter: AnyObject {
     var onDefaultLayoutButtonTappedCalled: Bool { get }
     var onSquareLayoutButtonTappedCalled: Bool { get }
     var onRectangleLayoutButtonTappedCalled: Bool { get }
+    var onUpdateTravelCalled: Bool { get }
     
     func onViewDidLoad()
     func onLayoutButtonTapped()
     func onDefaultLayoutButtonTapped()
     func onSquareLayoutButtonTapped()
     func onRectangleLayoutButtonTapped()
+    func onUpdateTravel()
 }

--- a/BoostPocket/BoostPocket/TravelListScene/TravelListSupport.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelListSupport.swift
@@ -1,0 +1,29 @@
+//
+//  TravelListSupport.swift
+//  BoostPocket
+//
+//  Created by sihyung you on 2020/12/13.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+import Foundation
+
+enum Layout {
+    case defaultLayout
+    case squareLayout
+    case rectangleLayout
+}
+
+protocol TravelListVCPresenter: AnyObject {
+    var onViewDidLoadCalled: Bool { get }
+    var onLayoutButtonTappedCalled: Bool { get }
+    var onDefaultLayoutButtonTappedCalled: Bool { get }
+    var onSquareLayoutButtonTappedCalled: Bool { get }
+    var onRectangleLayoutButtonTappedCalled: Bool { get }
+    
+    func onViewDidLoad()
+    func onLayoutButtonTapped()
+    func onDefaultLayoutButtonTapped()
+    func onSquareLayoutButtonTapped()
+    func onRectangleLayoutButtonTapped()
+}

--- a/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelListViewModel.swift
@@ -42,7 +42,7 @@ class TravelListViewModel: TravelListPresentable {
     }
     
     func createTravel(countryName: String, completion: @escaping (TravelItemViewModel?) -> Void) {
-        travelProvider?.createTravel(countryName: countryName) { [weak self] (createdTravel) in
+        travelProvider?.createTravel(countryName: countryName) { [weak self] createdTravel in
             guard let self = self,
                 let historyProvider = self.historyProvider,
                 let createdTravel = createdTravel else {

--- a/BoostPocket/BoostPocket/TravelListScene/TravelProvider.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/TravelProvider.swift
@@ -27,7 +27,7 @@ class TravelProvider: TravelProvidable {
     func createTravel(countryName: String, completion: @escaping (Travel?) -> Void) {
         let newTravelInfo = TravelInfo(countryName: countryName, id: UUID(), title: countryName, memo: nil, startDate: nil, endDate: nil, coverImage: Data().getCoverImage() ?? Data(), budget: Double(), exchangeRate: Double())
         
-        persistenceManager?.createObject(newObjectInfo: newTravelInfo) { [weak self] (createdObject) in
+        persistenceManager?.createObject(newObjectInfo: newTravelInfo) { [weak self] createdObject in
             guard let createdTravel = createdObject as? Travel else {
                 completion(nil)
                 return

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
@@ -79,7 +79,7 @@ class TravelListViewController: UIViewController {
     
     func applySnapShot(with travels: [TravelItemViewModel]) {
         var snapShot = SnapShot()
-
+        
         let sectionCaseCounts = getTravelSectionNumbers()
         
         snapShot.appendSections([TravelSection(travelSectionCase: .current, numberOfTravels: sectionCaseCounts[.current] ?? 0),
@@ -159,11 +159,11 @@ class TravelListViewController: UIViewController {
         
         countryListVC.countryListViewModel = countryListViewModel
         countryListVC.doneButtonHandler = { (selectedCountry) in
-            self.travelListViewModel?.createTravel(countryName: selectedCountry.name) { (travelItemViewModel) in
+            self.travelListViewModel?.createTravel(countryName: selectedCountry.name) { travelItemViewModel in
                 DispatchQueue.main.async {
                     guard let createdTravelItemViewModel = travelItemViewModel,
                         let tabBarVC = TravelDetailTabbarController.createTabbarVC(),
-                    let profileVC = tabBarVC.viewControllers?[0] as? TravelProfileViewController
+                        let profileVC = tabBarVC.viewControllers?[0] as? TravelProfileViewController
                         else { return }
                     
                     tabBarVC.setupChildViewControllers(with: createdTravelItemViewModel)
@@ -210,7 +210,7 @@ extension TravelListViewController: UICollectionViewDelegate {
         guard let selectedTravelViewModel = dataSource.itemIdentifier(for: indexPath),
             let tabBarVC = TravelDetailTabbarController.createTabbarVC(),
             let profileVC = tabBarVC.viewControllers?[0] as? TravelProfileViewController
-        else { return }
+            else { return }
         
         tabBarVC.setupChildViewControllers(with: selectedTravelViewModel)
         profileVC.profileDelegate = self

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
@@ -8,20 +8,6 @@
 
 import UIKit
 
-enum Layout {
-    case defaultLayout
-    case squareLayout
-    case rectangleLayout
-}
-
-protocol TravelListVCPresenter: AnyObject {
-    func onViewDidLoad()
-    func onLayoutButtonTapped()
-    func onDefaultLayoutButtonTapped()
-    func onSquareLayoutButtonTapped()
-    func onRectangleLayoutButtonTapped()
-}
-
 class TravelListViewController: UIViewController {
     static let identifier = "TravelListViewController"
     

--- a/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
+++ b/BoostPocket/BoostPocket/TravelListScene/View/TravelListViewController.swift
@@ -241,7 +241,9 @@ extension TravelListViewController: TravelProfileDelegate {
         }
     }
     
-    func updateTravel(id: UUID? = nil, newTitle: String? = nil, newMemo: String?, newStartDate: Date? = nil, newEndDate: Date? = nil, newCoverImage: Data? = nil, newBudget: Double? = nil, newExchangeRate: Double? = nil) {
+    func updateTravel(id: UUID? = nil, newTitle: String? = nil, newMemo: String? = nil, newStartDate: Date? = nil, newEndDate: Date? = nil, newCoverImage: Data? = nil, newBudget: Double? = nil, newExchangeRate: Double? = nil, completion: @escaping (Bool) -> Void) {
+        presenter?.onUpdateTravel()
+        
         if let travelListViewModel = travelListViewModel,
             let updatingId = id,
             let updatingTravel = travelListViewModel.travels.filter({ $0.id == updatingId }).first,
@@ -252,13 +254,15 @@ extension TravelListViewController: TravelProfileDelegate {
             travelListViewModel.updateTravel(countryName: countryName, id: updatingId, title: newTitle ?? title, memo: newMemo, startDate: newStartDate, endDate: newEndDate, coverImage: newCoverImage ?? coverImage, budget: newBudget ?? updatingTravel.budget, exchangeRate: newExchangeRate ?? updatingTravel.exchangeRate) { result in
                 if result {
                     print("여행 정보 업데이트 성공")
+                    completion(true)
                 } else {
                     print("여행 정보 업데이트 실패")
+                    completion(false)
                 }
             }
-            
         } else {
             print("여행 업데이트를 위한 정보 불러오기 실패")
+            completion(false)
         }
     }
 }

--- a/BoostPocket/BoostPocketTests/TravelListVCTests.swift
+++ b/BoostPocket/BoostPocketTests/TravelListVCTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import NetworkManager
 @testable import BoostPocket
 
 class TravelListVCPresenterMock: TravelListVCPresenter {
@@ -15,7 +16,7 @@ class TravelListVCPresenterMock: TravelListVCPresenter {
     var onDefaultLayoutButtonTappedCalled: Bool = false
     var onSquareLayoutButtonTappedCalled: Bool = false
     var onRectangleLayoutButtonTappedCalled: Bool = false
-    
+    var onUpdateTravelCalled: Bool = false
     
     func onViewDidLoad() {
         onViewDidLoadCalled = true
@@ -36,6 +37,10 @@ class TravelListVCPresenterMock: TravelListVCPresenter {
     func onRectangleLayoutButtonTapped() {
         onRectangleLayoutButtonTappedCalled = true
     }
+
+    func onUpdateTravel() {
+        onUpdateTravelCalled = true
+    }
 }
 
 class TravelListVCTests: XCTestCase {
@@ -50,9 +55,52 @@ class TravelListVCTests: XCTestCase {
         return sut
     }
     
-    override func setUpWithError() throws { }
+    var travelListViewModel: TravelListPresentable!
+    var persistenceManagerStub: PersistenceManagable!
+    var countryProvider: CountryProvidable!
+    var travelProvider: TravelProvidable!
+    var historyProvider: HistoryProvider!
+    var dataLoader: DataLoader?
+    let countriesExpectation = XCTestExpectation(description: "Successfully Created Countries")
+    
+    let id = UUID()
+    let title = "test title"
+    let memo = "memo"
+    let budget = 3.29
+    let coverImage = Data()
+    let startDate = Date()
+    let endDate = Date()
+    let exchangeRate = 12.1
+    let countryName = "대한민국"
+    let lastUpdated = "2019-08-23".convertToDate()
+    let flagImage = Data()
+    let currencyCode = "KRW"
+    
+    override func setUpWithError() throws {
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+        let dataLoader = DataLoader(session: session)
+        persistenceManagerStub = PersistenceManagerStub(dataLoader: dataLoader)
+        
+        persistenceManagerStub.createCountriesWithAPIRequest { [weak self] (result) in
+            if result {
+                self?.countriesExpectation.fulfill()
+            }
+        }
+        
+        countryProvider = CountryProvider(persistenceManager: persistenceManagerStub)
+        travelProvider = TravelProvider(persistenceManager: persistenceManagerStub)
+        historyProvider = HistoryProvider(persistenceManager: persistenceManagerStub)
+        
+        travelListViewModel = TravelListViewModel(countryProvider: countryProvider, travelProvider: travelProvider, historyProvider: historyProvider)
 
-    override func tearDownWithError() throws { }
+        self.dataLoader = dataLoader
+    }
+
+    override func tearDownWithError() throws {
+        travelListViewModel = nil
+        travelProvider = nil
+        persistenceManagerStub = nil
+    }
 
     func test_travelListVC_viewDidLoad() {
         let sut = makeSUT()
@@ -90,5 +138,58 @@ class TravelListVCTests: XCTestCase {
         sut.layoutButtonTapped(sut.layoutButtons[2])
         XCTAssertTrue(presenter.onRectangleLayoutButtonTappedCalled)
         XCTAssertEqual(sut.layout, Layout.rectangleLayout)
+    }
+    
+    func test_travelListVC_updateTravelFail() {
+        let sut = makeSUT()
+        
+        let updateTravelExpectation = XCTestExpectation(description: "Successfully Updated Travel")
+        
+        sut.updateTravel { result in
+            XCTAssertFalse(result)
+            updateTravelExpectation.fulfill()
+        }
+        
+        wait(for: [updateTravelExpectation], timeout: 1)
+        XCTAssertTrue(presenter.onUpdateTravelCalled)
+    }
+    
+    func test_travelListVC_updateTravelPass() {
+        // create countries
+        wait(for: [countriesExpectation], timeout: 2)
+        
+        let sut = makeSUT()
+        sut.travelListViewModel = travelListViewModel
+        
+        // create travel
+        let fetchedCountries = countryProvider.fetchCountries()
+        let firstCountry = fetchedCountries.first
+        XCTAssertNotNil(fetchedCountries)
+        XCTAssertNotNil(firstCountry)
+        
+        let travelExpectation = XCTestExpectation(description: "Successfully Created Travel")
+        var createdTravelItemViewModel: TravelItemViewModel?
+        
+        sut.travelListViewModel?.createTravel(countryName: countryName) { travelItemViewModel in
+            createdTravelItemViewModel = travelItemViewModel
+            XCTAssertNotNil(createdTravelItemViewModel)
+            travelExpectation.fulfill()
+        }
+
+        wait(for: [travelExpectation], timeout: 3)
+        
+        // update travel
+        let updateTravelExpectation = XCTestExpectation(description: "Successfully Updated Travel")
+        
+        sut.updateTravel(id: createdTravelItemViewModel?.id, newTitle: "new title", newMemo: "new memo", newStartDate: startDate, newEndDate: endDate, newCoverImage: coverImage, newBudget: 0, newExchangeRate: exchangeRate) { result in
+            if result {
+                XCTAssertTrue(result)
+                updateTravelExpectation.fulfill()
+            }
+        }
+        
+        wait(for: [updateTravelExpectation], timeout: 4)
+        XCTAssertTrue(presenter.onUpdateTravelCalled)
+        
     }
 }

--- a/BoostPocket/BoostPocketTests/TravelListVCTests.swift
+++ b/BoostPocket/BoostPocketTests/TravelListVCTests.swift
@@ -10,11 +10,12 @@ import XCTest
 @testable import BoostPocket
 
 class TravelListVCPresenterMock: TravelListVCPresenter {
-    private(set) var onViewDidLoadCalled = false
-    private(set) var onLayoutButtonTappedCalled = false
-    private(set) var onDefaultLayoutButtonTappedCalled = false
-    private(set) var onSquareLayoutButtonTappedCalled = false
-    private(set) var onRectangleLayoutButtonTappedCalled = false
+    var onViewDidLoadCalled: Bool = false
+    var onLayoutButtonTappedCalled: Bool = false
+    var onDefaultLayoutButtonTappedCalled: Bool = false
+    var onSquareLayoutButtonTappedCalled: Bool = false
+    var onRectangleLayoutButtonTappedCalled: Bool = false
+    
     
     func onViewDidLoad() {
         onViewDidLoadCalled = true

--- a/BoostPocket/BoostPocketTests/TravelProfileVCTests.swift
+++ b/BoostPocket/BoostPocketTests/TravelProfileVCTests.swift
@@ -1,0 +1,59 @@
+//
+//  TravelProfileVCTests.swift
+//  BoostPocketTests
+//
+//  Created by sihyung you on 2020/12/13.
+//  Copyright © 2020 BoostPocket. All rights reserved.
+//
+
+import XCTest
+@testable import BoostPocket
+
+class TravelProfileVCPresenterMock: TravelProfileVCPresenter {
+    var onViewDidLoadCalled: Bool = false
+    var onMemoLabelTappedCalled: Bool = false
+    var onStartDateSelectedCalled: Bool = false
+    
+    func onViewDidLoad() {
+        onViewDidLoadCalled = true
+    }
+    
+    func onMemoLabelTapped() {
+        onMemoLabelTappedCalled = true
+    }
+    
+    func onStartDateSelected() {
+        onStartDateSelectedCalled = true
+    }
+}
+
+class TravelProfileVCTests: XCTestCase {
+    let presenter = TravelProfileVCPresenterMock()
+    
+    func makeSUT() -> TravelProfileViewController {
+        let storyboard = UIStoryboard(name: "TravelDetail", bundle: nil)
+        guard let sut = storyboard.instantiateViewController(identifier: TravelProfileViewController.identifier) as? TravelProfileViewController else { return TravelProfileViewController() }
+        
+        sut.presenter = presenter
+        sut.loadViewIfNeeded()
+        return sut
+    }
+    
+    override func setUpWithError() throws { }
+
+    override func tearDownWithError() throws { }
+    
+    func test_travelProfileVC_viewDidLoad() {
+        let sut = makeSUT()
+        sut.viewDidLoad()
+        
+        XCTAssertTrue(presenter.onViewDidLoadCalled)
+    }
+    
+    func test_travelProfileVC_startDateSelected() {
+        let sut = makeSUT()
+
+        sut.startDateSelected(UIDatePicker())
+        XCTAssertTrue(presenter.onStartDateSelectedCalled)
+    }
+}

--- a/BoostPocket/BoostPocketTests/TravelProfileVCTests.swift
+++ b/BoostPocket/BoostPocketTests/TravelProfileVCTests.swift
@@ -49,11 +49,4 @@ class TravelProfileVCTests: XCTestCase {
         
         XCTAssertTrue(presenter.onViewDidLoadCalled)
     }
-    
-    func test_travelProfileVC_startDateSelected() {
-        let sut = makeSUT()
-
-        sut.startDateSelected(UIDatePicker())
-        XCTAssertTrue(presenter.onStartDateSelectedCalled)
-    }
 }


### PR DESCRIPTION
### 변경사항
- HistoryListSupport, TravelListSupport 파일을 생성하여 테스트를 위한 프로토콜,
  혹은 enum 등과 같은 데이터 구조 코드를 옮겨놓음
- TravelListVC - updaetTravel 함수 통합테스트 작성
- TravelProfileVC - title/memo/start, end date/coverImage 업데이트에 대해 실제
  데이터 업데이트가 성공했을 때에만 뷰를 업데이트 하도록 구조 변경
- TestProfileVC 테스트코드 틀만 잡는 정도로 작성
- history내역을 삭제하지 않아 여행 삭제가 불가능하던 오류 수정
- travel delete 시, 먼저 해당 여행에 속한 모든 history를 코어데이터에서 삭제하도록
  변경
- presentAlertView 함수를 작성하여 삭제버튼/업데이트 실패 시 Alert를 띄우는 코드를
  하나의 함수로 통일

### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
