### PR TITLE
지출 추가화면에서 숫자가 커질 때 발생하는 문제 해결

### DIFF
--- a/BoostPocket/BoostPocket/Extensions/Double+/Double+NumberFormat.swift
+++ b/BoostPocket/BoostPocket/Extensions/Double+/Double+NumberFormat.swift
@@ -18,4 +18,12 @@ extension Double {
         guard let formattedNumber = numberFormatter.string(from: NSNumber(value: self)) else { return String(self) }
         return formattedNumber
     }
+    
+    func convertToString() -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
+        guard let formattedNumber = numberFormatter.string(from: NSNumber(value: self)) else { return String(self) }
+        
+        return formattedNumber.replacingOccurrences(of: ",", with: "")
+    }
 }

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.swift
@@ -129,8 +129,8 @@ class AddHistoryViewController: UIViewController {
         calculatedAmountLabel.textColor = .white
         if let previousAmount = baseHistoryViewModel.amount {
             self.amount = previousAmount
-            calculatorExpressionLabel.text = "\(previousAmount)"
-            calculatedAmountLabel.text = "\(previousAmount)"
+            calculatorExpressionLabel.text = previousAmount.convertToString()
+            calculatedAmountLabel.text = previousAmount.convertToString()
             currencyConvertedAmountLabel.text = "KRW \((previousAmount / baseHistoryViewModel.exchangeRate).getCurrencyFormat(identifier: baseHistoryViewModel.countryIdentifier ?? ""))"
         } else {
             calculatorExpressionLabel.text = "0"
@@ -236,8 +236,8 @@ class AddHistoryViewController: UIViewController {
     }
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {
-        guard amount > 0 else {
-            let alert = UIAlertController(title: "금액을 입력해주세요!", message: "", preferredStyle: UIAlertController.Style.alert)
+        guard amount > 0, !amount.isNaN, !amount.isInfinite else {
+            let alert = UIAlertController(title: "금액을 확인해주세요!", message: "", preferredStyle: UIAlertController.Style.alert)
             let okAction = UIAlertAction(title: "확인", style: .default)
             alert.addAction(okAction)
             present(alert, animated: true, completion: nil)

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.xib
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.xib
@@ -310,22 +310,36 @@
                     </subviews>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uvo-Ni-ty9" userLabel="Line 0">
-                    <rect key="frame" x="20" y="503.5" width="394" height="45"/>
+                    <rect key="frame" x="0.0" y="503.5" width="414" height="45"/>
                     <subviews>
-                        <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="FBN-Xp-w8g">
-                            <rect key="frame" x="0.0" y="0.0" width="239" height="45"/>
-                            <locale key="locale" localeIdentifier="ko"/>
-                        </datePicker>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5UH-g4-mMe" userLabel="Picture">
-                            <rect key="frame" x="239" y="0.0" width="51.5" height="45"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RWq-Ek-2dx">
+                            <rect key="frame" x="0.0" y="0.0" width="259" height="45"/>
+                            <subviews>
+                                <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="FBN-Xp-w8g">
+                                    <rect key="frame" x="20" y="0.0" width="219" height="45"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="219" id="UH0-dh-oF4"/>
+                                    </constraints>
+                                    <locale key="locale" localeIdentifier="ko"/>
+                                </datePicker>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstItem="FBN-Xp-w8g" firstAttribute="centerX" secondItem="RWq-Ek-2dx" secondAttribute="centerX" id="40g-uB-nBS"/>
+                                <constraint firstAttribute="bottom" secondItem="FBN-Xp-w8g" secondAttribute="bottom" id="Rhp-K0-hy3"/>
+                                <constraint firstItem="FBN-Xp-w8g" firstAttribute="top" secondItem="RWq-Ek-2dx" secondAttribute="top" id="SUa-oX-KvR"/>
+                            </constraints>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5UH-g4-mMe" userLabel="Picture">
+                            <rect key="frame" x="259" y="0.0" width="51.5" height="45"/>
                             <color key="tintColor" systemColor="systemGray3Color"/>
                             <state key="normal" image="photo" catalog="system"/>
                             <connections>
                                 <action selector="addImageButtonTapped:" destination="-1" eventType="touchUpInside" id="LG4-Eq-Ho1"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14w-LZ-14y" userLabel="Memo">
-                            <rect key="frame" x="290.5" y="0.0" width="52" height="45"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14w-LZ-14y" userLabel="Memo">
+                            <rect key="frame" x="310.5" y="0.0" width="52" height="45"/>
                             <color key="tintColor" systemColor="systemGray3Color"/>
                             <state key="normal" image="list.dash" catalog="system"/>
                             <connections>
@@ -333,7 +347,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-oJ-N8p">
-                            <rect key="frame" x="342.5" y="0.0" width="51.5" height="45"/>
+                            <rect key="frame" x="362.5" y="0.0" width="51.5" height="45"/>
                             <state key="normal" title="저장"/>
                             <connections>
                                 <action selector="saveButtonTapped:" destination="-1" eventType="touchUpInside" id="XTN-WY-cDN"/>
@@ -341,8 +355,7 @@
                         </button>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="14w-LZ-14y" firstAttribute="leading" secondItem="5UH-g4-mMe" secondAttribute="trailing" id="3VQ-J2-zBT"/>
-                        <constraint firstItem="QIf-oJ-N8p" firstAttribute="leading" secondItem="14w-LZ-14y" secondAttribute="trailing" id="StW-zK-adn"/>
+                        <constraint firstItem="14w-LZ-14y" firstAttribute="width" secondItem="5UH-g4-mMe" secondAttribute="width" id="OGg-Z8-d2O"/>
                     </constraints>
                 </stackView>
                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RY6-19-kNJ">
@@ -384,7 +397,7 @@
                 <constraint firstItem="Uvo-Ni-ty9" firstAttribute="top" secondItem="RY6-19-kNJ" secondAttribute="bottom" constant="15" id="LX4-ke-6CR"/>
                 <constraint firstItem="0kX-Kl-MDd" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.35" id="NK5-JK-lX7"/>
                 <constraint firstItem="heQ-Ap-lf8" firstAttribute="top" secondItem="fLx-PJ-SRJ" secondAttribute="bottom" constant="10" id="NWT-Gj-UAR"/>
-                <constraint firstItem="Uvo-Ni-ty9" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="Q7Q-qd-fTQ"/>
+                <constraint firstItem="Uvo-Ni-ty9" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Q7Q-qd-fTQ"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="RY6-19-kNJ" secondAttribute="trailing" id="SSf-MM-xZK"/>
                 <constraint firstItem="RY6-19-kNJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="VW7-0O-CiC"/>
                 <constraint firstItem="Uvo-Ni-ty9" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.05" id="aew-P5-zSc"/>

--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.xib
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.xib
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -41,7 +43,7 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="158"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지출/수입" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X8B-Q2-jmd" customClass="PaddedLabel" customModule="BoostPocket" customModuleProvider="target">
-                            <rect key="frame" x="182.5" y="10" width="49.5" height="16"/>
+                            <rect key="frame" x="182.5" y="10" width="49" height="16"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -61,7 +63,7 @@
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tkA-TC-4Rx" userLabel="Expression">
-                            <rect key="frame" x="155" y="31" width="249" height="20.5"/>
+                            <rect key="frame" x="154.5" y="31" width="249.5" height="20.5"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="wt4-sK-9dJ"/>
                             </constraints>
@@ -70,19 +72,19 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aLb-EL-GfB" userLabel="Currency Converted">
-                            <rect key="frame" x="155" y="107.5" width="249" height="40.5"/>
+                            <rect key="frame" x="154.5" y="107.5" width="249.5" height="40.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qEf-JD-335" userLabel="Currency Code">
-                            <rect key="frame" x="103" y="69.5" width="42" height="20.5"/>
+                            <rect key="frame" x="103" y="69.5" width="41.5" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="20" translatesAutoresizingMaskIntoConstraints="NO" id="4pe-9q-UpJ" userLabel="Amount">
-                            <rect key="frame" x="155" y="61.5" width="249" height="36"/>
+                            <rect key="frame" x="154.5" y="61.5" width="249.5" height="36"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -127,7 +129,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="zNC-ne-17w" userLabel="Line 1">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="78.5"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pnc-fS-OM8">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pnc-fS-OM8">
                                     <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="1">
@@ -137,7 +139,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="U5M-Pv-OdA"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="blA-Xr-rfk">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="blA-Xr-rfk">
                                     <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="2">
@@ -147,7 +149,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="nDh-so-2N8"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o0M-UP-Rk5">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o0M-UP-Rk5">
                                     <rect key="frame" x="207" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="3">
@@ -157,7 +159,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="uU4-PZ-XuC"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yad-QF-DSb">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yad-QF-DSb">
                                     <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="/">
@@ -172,7 +174,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="TVS-ym-BML" userLabel="Line 2">
                             <rect key="frame" x="0.0" y="78.5" width="414" height="78"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L5d-QI-dZG">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L5d-QI-dZG">
                                     <rect key="frame" x="0.0" y="0.0" width="103.5" height="78"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="4">
@@ -182,7 +184,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="v2S-OL-bKc"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uqZ-Zx-Nzq">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uqZ-Zx-Nzq">
                                     <rect key="frame" x="103.5" y="0.0" width="103.5" height="78"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="5">
@@ -192,7 +194,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="OwG-6A-30c"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TEQ-Wv-51m">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TEQ-Wv-51m">
                                     <rect key="frame" x="207" y="0.0" width="103.5" height="78"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="6">
@@ -202,7 +204,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="n0L-7g-9nc"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpW-m6-gJK">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpW-m6-gJK">
                                     <rect key="frame" x="310.5" y="0.0" width="103.5" height="78"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="*">
@@ -217,7 +219,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="mTC-rY-0q7" userLabel="Line 3">
                             <rect key="frame" x="0.0" y="156.5" width="414" height="78.5"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eb0-or-e7a">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eb0-or-e7a">
                                     <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="7">
@@ -227,7 +229,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="6qK-ZD-ZHw"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vDc-72-ZGQ">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vDc-72-ZGQ">
                                     <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="8">
@@ -237,7 +239,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="uq3-yZ-VsB"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dO6-ES-U6p">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dO6-ES-U6p">
                                     <rect key="frame" x="207" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="9">
@@ -247,7 +249,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="Drk-Pm-02K"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gMU-9A-ueg">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gMU-9A-ueg">
                                     <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="+">
@@ -262,7 +264,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="USD-XQ-8mw" userLabel="Line 4">
                             <rect key="frame" x="0.0" y="235" width="414" height="78.5"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="59c-I8-mls">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="59c-I8-mls">
                                     <rect key="frame" x="0.0" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title=".">
@@ -272,7 +274,7 @@
                                         <action selector="btnNumberWithSender:" destination="-1" eventType="touchUpInside" id="g1B-hj-p7H"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZL6-uO-xEa">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZL6-uO-xEa">
                                     <rect key="frame" x="103.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="0">
@@ -293,7 +295,7 @@
                                         <action selector="backTapped:" destination="-1" eventType="touchUpInside" id="Grj-Zy-igZ"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hcc-d6-yrA">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hcc-d6-yrA">
                                     <rect key="frame" x="310.5" y="0.0" width="103.5" height="78.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <state key="normal" title="-">
@@ -307,31 +309,31 @@
                         </stackView>
                     </subviews>
                 </stackView>
-                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="Uvo-Ni-ty9" userLabel="Line 0">
-                    <rect key="frame" x="0.0" y="503.5" width="414" height="45"/>
+                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uvo-Ni-ty9" userLabel="Line 0">
+                    <rect key="frame" x="20" y="503.5" width="394" height="45"/>
                     <subviews>
                         <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="FBN-Xp-w8g">
-                            <rect key="frame" x="0.0" y="0.0" width="259" height="45"/>
+                            <rect key="frame" x="0.0" y="0.0" width="239" height="45"/>
                             <locale key="locale" localeIdentifier="ko"/>
                         </datePicker>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5UH-g4-mMe" userLabel="Picture">
-                            <rect key="frame" x="259" y="0.0" width="51.5" height="45"/>
-                            <color key="tintColor" systemColor="systemGray3Color" red="0.78039215689999997" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <rect key="frame" x="239" y="0.0" width="51.5" height="45"/>
+                            <color key="tintColor" systemColor="systemGray3Color"/>
                             <state key="normal" image="photo" catalog="system"/>
                             <connections>
                                 <action selector="addImageButtonTapped:" destination="-1" eventType="touchUpInside" id="LG4-Eq-Ho1"/>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14w-LZ-14y" userLabel="Memo">
-                            <rect key="frame" x="310.5" y="0.0" width="52" height="45"/>
-                            <color key="tintColor" systemColor="systemGray3Color" red="0.78039215689999997" green="0.78039215689999997" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <rect key="frame" x="290.5" y="0.0" width="52" height="45"/>
+                            <color key="tintColor" systemColor="systemGray3Color"/>
                             <state key="normal" image="list.dash" catalog="system"/>
                             <connections>
                                 <action selector="addMemoButtonTapped:" destination="-1" eventType="touchUpInside" id="c6o-T4-531"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-oJ-N8p">
-                            <rect key="frame" x="362.5" y="0.0" width="51.5" height="45"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-oJ-N8p">
+                            <rect key="frame" x="342.5" y="0.0" width="51.5" height="45"/>
                             <state key="normal" title="저장"/>
                             <connections>
                                 <action selector="saveButtonTapped:" destination="-1" eventType="touchUpInside" id="XTN-WY-cDN"/>
@@ -351,14 +353,14 @@
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lci-Ei-eGZ" userLabel="Divider">
                     <rect key="frame" x="62" y="477.5" width="290" height="1"/>
-                    <color key="backgroundColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="backgroundColor" systemColor="systemGray2Color"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="a2a-5Y-BCG"/>
                     </constraints>
                 </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="heQ-Ap-lf8">
                     <rect key="frame" x="0.0" y="212" width="414" height="255.5"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="V01-ce-Dyy">
                         <size key="itemSize" width="128" height="128"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -367,7 +369,8 @@
                     </collectionViewFlowLayout>
                 </collectionView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="lci-Ei-eGZ" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="4iX-Zc-Elj"/>
                 <constraint firstItem="0kX-Kl-MDd" firstAttribute="top" secondItem="Uvo-Ni-ty9" secondAttribute="bottom" id="5dm-zO-9oG"/>
@@ -381,7 +384,7 @@
                 <constraint firstItem="Uvo-Ni-ty9" firstAttribute="top" secondItem="RY6-19-kNJ" secondAttribute="bottom" constant="15" id="LX4-ke-6CR"/>
                 <constraint firstItem="0kX-Kl-MDd" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.35" id="NK5-JK-lX7"/>
                 <constraint firstItem="heQ-Ap-lf8" firstAttribute="top" secondItem="fLx-PJ-SRJ" secondAttribute="bottom" constant="10" id="NWT-Gj-UAR"/>
-                <constraint firstItem="Uvo-Ni-ty9" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Q7Q-qd-fTQ"/>
+                <constraint firstItem="Uvo-Ni-ty9" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="Q7Q-qd-fTQ"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="RY6-19-kNJ" secondAttribute="trailing" id="SSf-MM-xZK"/>
                 <constraint firstItem="RY6-19-kNJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="VW7-0O-CiC"/>
                 <constraint firstItem="Uvo-Ni-ty9" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.05" id="aew-P5-zSc"/>
@@ -394,7 +397,6 @@
                 <constraint firstItem="QIf-oJ-N8p" firstAttribute="leading" secondItem="Yad-QF-DSb" secondAttribute="centerX" id="yzg-D4-CxD"/>
                 <constraint firstItem="RY6-19-kNJ" firstAttribute="top" secondItem="lci-Ei-eGZ" secondAttribute="bottom" constant="10" id="zB8-II-ahG"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="131.8840579710145" y="150.66964285714286"/>
         </view>
     </objects>
@@ -405,5 +407,14 @@
         <namedColor name="basicBlackTextColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGray3Color">
+            <color red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailScene/HistoryDetailViewController.swift
+++ b/BoostPocket/BoostPocket/TravelDetailScene/HistoryDetailScene/HistoryDetailViewController.swift
@@ -87,7 +87,7 @@ class HistoryDetailViewController: UIViewController {
         historyDateLabel.text = history.currentDate.convertToString(format: .fullKoreanDated)
         if let category = history.category, let title = history.title, let amount = history.amount, let identifier = history.countryIdentifier {
             amountLabel.text = "\(identifier.currencySymbol) \(amount.getCurrencyFormat(identifier: identifier))"
-            exchangedMoneyLabel.text = "KRW \((amount / history.exchangeRate).getCurrencyFormat(identifier: identifier))"
+            exchangedMoneyLabel.text = "KRW \((amount / history.exchangeRate).getCurrencyFormat(identifier: "ko_KR"))"
             categoryImageView.image = UIImage(named: category.imageName)
             titleLabel.text = title.isEmpty ? category.name : title
         }

--- a/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
+++ b/BoostPocket/BoostPocket/TravelDetailScene/TravelDetail.storyboard
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,7 +21,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ALI-AJ-0ck" userLabel="Divider">
                                 <rect key="frame" x="118.5" y="50" width="0.0" height="47"/>
-                                <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="0.29999999999999999" id="jZE-uh-4VG"/>
                                 </constraints>
@@ -56,7 +58,7 @@
                                         </constraints>
                                     </scrollView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="NrH-bA-9YK" secondAttribute="bottom" id="BeG-kR-7Bc"/>
                                     <constraint firstItem="jFB-Ve-ziB" firstAttribute="height" secondItem="Z3N-xh-feq" secondAttribute="height" id="Uxo-A3-1Jj"/>
@@ -77,21 +79,21 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4RM-9s-J1O">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4RM-9s-J1O">
                                                 <rect key="frame" x="15" y="7" width="29.5" height="29.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="4RM-9s-J1O" secondAttribute="height" multiplier="1:1" id="y2f-Gy-RwD"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <state key="normal" title="A">
-                                                    <color key="titleColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="titleColor" systemColor="labelColor"/>
                                                 </state>
                                                 <connections>
                                                     <action selector="isPrepareButtonTapped:" destination="fmi-ND-nuS" eventType="touchUpInside" id="0Xs-Hi-ViN"/>
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="4RM-9s-J1O" firstAttribute="width" secondItem="Nhk-Y4-RcI" secondAttribute="width" multiplier="0.5" id="AqU-4x-YGi"/>
                                             <constraint firstItem="PJt-Ce-JhI" firstAttribute="centerY" secondItem="Nhk-Y4-RcI" secondAttribute="centerY" constant="12" id="KgW-aM-uUT"/>
@@ -109,21 +111,21 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TGX-v2-Of4">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TGX-v2-Of4">
                                                 <rect key="frame" x="15" y="7" width="29.5" height="29.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="TGX-v2-Of4" secondAttribute="height" multiplier="1:1" id="h58-gb-NIS"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <state key="normal" title="P">
-                                                    <color key="titleColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="titleColor" systemColor="labelColor"/>
                                                 </state>
                                                 <connections>
                                                     <action selector="isPrepareButtonTapped:" destination="fmi-ND-nuS" eventType="touchUpInside" id="pAP-qG-aBh"/>
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="TGX-v2-Of4" firstAttribute="centerX" secondItem="lNX-mS-vBO" secondAttribute="centerX" id="6ut-c0-tre"/>
                                             <constraint firstItem="TGX-v2-Of4" firstAttribute="width" secondItem="lNX-mS-vBO" secondAttribute="width" multiplier="0.5" id="KuB-dD-SZG"/>
@@ -139,7 +141,7 @@
                             </stackView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7Iu-bN-RtM">
                                 <rect key="frame" x="0.0" y="134" width="414" height="600"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Pz-Vt-NSM" customClass="TotalAmountView" customModule="BoostPocket" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="734" width="414" height="79"/>
@@ -164,7 +166,7 @@
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TiB-LT-87K">
                                         <rect key="frame" x="207" y="8" width="0.5" height="63"/>
-                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="0.5" id="0RV-jI-YhL"/>
                                         </constraints>
@@ -247,7 +249,8 @@
                                 </constraints>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="gwU-vf-3l1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="tBh-oz-M9X" firstAttribute="bottom" secondItem="7Iu-bN-RtM" secondAttribute="bottom" constant="-15" id="1aI-qT-0V7"/>
                             <constraint firstItem="Ymo-4K-Sav" firstAttribute="centerX" secondItem="oSf-dj-s8a" secondAttribute="centerX" id="1ap-sW-gdw"/>
@@ -278,7 +281,6 @@
                             <constraint firstItem="gwU-vf-3l1" firstAttribute="trailing" secondItem="7Iu-bN-RtM" secondAttribute="trailing" id="wEg-GL-uo8"/>
                             <constraint firstItem="Pfa-3M-wrJ" firstAttribute="width" secondItem="oSf-dj-s8a" secondAttribute="width" multiplier="0.48" id="yFp-Ec-JZ6"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="gwU-vf-3l1"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="지출목록" image="list.bullet" catalog="system" id="wRC-jA-Szt"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -316,7 +318,7 @@
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0DJ-XU-Ifo" customClass="ReportPieChartView" customModule="BoostPocket" customModuleProvider="target">
                                                 <rect key="frame" x="41.5" y="109.5" width="331" height="331"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0DJ-XU-Ifo" secondAttribute="height" multiplier="1:1" id="oZH-4X-xPM"/>
                                                 </constraints>
@@ -356,7 +358,7 @@
                                                     </imageView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gfA-9A-qOs" userLabel="Divider">
                                                         <rect key="frame" x="0.0" y="112" width="331" height="1"/>
-                                                        <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="1" id="3cT-UB-6X5"/>
                                                         </constraints>
@@ -368,7 +370,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstItem="3Ty-TL-dYc" firstAttribute="top" secondItem="yfq-Sb-hGQ" secondAttribute="top" id="4Dn-hJ-Rvr"/>
                                                     <constraint firstAttribute="bottom" secondItem="gfA-9A-qOs" secondAttribute="bottom" id="6mj-Xc-jME"/>
@@ -393,7 +395,7 @@
                                                 <rect key="frame" x="41.5" y="603.5" width="331" height="118.5"/>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="0DJ-XU-Ifo" firstAttribute="top" secondItem="Kar-kh-qej" secondAttribute="bottom" constant="50" id="86E-NW-Mx1"/>
                                             <constraint firstAttribute="bottom" secondItem="t7t-L2-t41" secondAttribute="bottom" constant="20" id="EBB-Jh-xSa"/>
@@ -419,14 +421,14 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="dz2-Wq-4eW"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Ym4-MA-8an" firstAttribute="top" secondItem="dz2-Wq-4eW" secondAttribute="top" id="2Nb-Rf-Sla"/>
                             <constraint firstItem="dz2-Wq-4eW" firstAttribute="bottom" secondItem="Ym4-MA-8an" secondAttribute="bottom" id="aRZ-Mq-BQe"/>
                             <constraint firstItem="dz2-Wq-4eW" firstAttribute="trailing" secondItem="Ym4-MA-8an" secondAttribute="trailing" id="fgo-5M-GzJ"/>
                             <constraint firstItem="Ym4-MA-8an" firstAttribute="leading" secondItem="dz2-Wq-4eW" secondAttribute="leading" id="jCR-YY-O6y"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="dz2-Wq-4eW"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="리포트" image="chart.pie.fill" catalog="system" id="hU1-KU-wkB"/>
                     <connections>
@@ -463,15 +465,15 @@
                                             <subviews>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ngs-Bg-0Xj">
                                                     <rect key="frame" x="10" y="20" width="354" height="268"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                                    <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 </textView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="lvB-TX-H2s">
                                                     <rect key="frame" x="0.0" y="288" width="374" height="70"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-8R-MDG">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-8R-MDG">
                                                             <rect key="frame" x="0.0" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <state key="normal" title="취소">
@@ -481,7 +483,7 @@
                                                                 <action selector="cancelButtonTapped:" destination="7AX-5V-hys" eventType="touchUpInside" id="pJf-ns-WVd"/>
                                                             </connections>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Weu-7S-Dg6">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Weu-7S-Dg6">
                                                             <rect key="frame" x="187" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <state key="normal" title="완료">
@@ -497,7 +499,7 @@
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstItem="Ngs-Bg-0Xj" firstAttribute="leading" secondItem="cfT-us-jdV" secondAttribute="leading" constant="10" id="HOk-Hq-3mB"/>
                                                 <constraint firstItem="Ngs-Bg-0Xj" firstAttribute="top" secondItem="cfT-us-jdV" secondAttribute="top" constant="20" id="IbE-4r-ZTp"/>
@@ -523,7 +525,8 @@
                                 <blurEffect style="dark"/>
                             </visualEffectView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="tsh-cb-G6F"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="2y1-T4-y8R" firstAttribute="leading" secondItem="nnu-cz-oT4" secondAttribute="leading" id="IUN-qK-PlL"/>
                             <constraint firstAttribute="bottom" secondItem="2y1-T4-y8R" secondAttribute="bottom" id="Oha-3E-sDm"/>
@@ -531,7 +534,6 @@
                             <constraint firstAttribute="trailing" secondItem="2y1-T4-y8R" secondAttribute="trailing" id="kWs-Fn-Nle"/>
                             <constraint firstItem="cfT-us-jdV" firstAttribute="height" secondItem="nnu-cz-oT4" secondAttribute="height" multiplier="0.4" id="yCN-Ju-RMh"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="tsh-cb-G6F"/>
                     </view>
                     <connections>
                         <outlet property="memoTextView" destination="Ngs-Bg-0Xj" id="MC5-YO-gnw"/>
@@ -733,7 +735,7 @@
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                         </subviews>
-                                                                        <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                         <constraints>
                                                                             <constraint firstItem="XiF-QM-NZR" firstAttribute="width" secondItem="qvF-Ok-csh" secondAttribute="width" multiplier="0.95" id="2tp-xA-jbd"/>
                                                                             <constraint firstItem="Cgj-k5-VFd" firstAttribute="top" secondItem="qvF-Ok-csh" secondAttribute="top" id="Flf-h1-W0M"/>
@@ -748,13 +750,13 @@
                                                                         <rect key="frame" x="0.0" y="104" width="374" height="16"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="₩ 25,000 사용" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V5d-JZ-sid">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="185" height="16"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="185.5" height="16"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" name="basicGrayTextColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KRW 15,000 남음/₩ 23,000 초과" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rmn-Fr-kXg">
-                                                                                <rect key="frame" x="185" y="0.0" width="189" height="16"/>
+                                                                                <rect key="frame" x="185.5" y="0.0" width="188.5" height="16"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" name="basicBlackTextColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -789,7 +791,7 @@
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eHl-w2-LWW" userLabel="Button View">
                                                                 <rect key="frame" x="0.0" y="1322" width="374" height="37.5"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIM-lz-bbD" userLabel="여행 삭제하기">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIM-lz-bbD" userLabel="여행 삭제하기">
                                                                         <rect key="frame" x="131" y="0.0" width="112" height="37.5"/>
                                                                         <color key="backgroundColor" name="deleteButtonColor"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
@@ -807,7 +809,7 @@
                                                                         </connections>
                                                                     </button>
                                                                 </subviews>
-                                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <constraints>
                                                                     <constraint firstItem="eIM-lz-bbD" firstAttribute="top" secondItem="eHl-w2-LWW" secondAttribute="top" id="GmL-Jd-PP6"/>
                                                                     <constraint firstAttribute="width" secondItem="eHl-w2-LWW" secondAttribute="height" multiplier="10:1" id="MIb-du-ecy"/>
@@ -825,7 +827,7 @@
                                                         </constraints>
                                                     </stackView>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="bottom" secondItem="Ma0-RF-0Rk" secondAttribute="bottom" constant="20" id="0mA-rw-gX3"/>
                                                     <constraint firstItem="Ma0-RF-0Rk" firstAttribute="leading" secondItem="6aw-iA-A5G" secondAttribute="leading" constant="20" id="6Zs-hF-1E0"/>
@@ -842,7 +844,7 @@
                                         </constraints>
                                     </scrollView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="ux4-FQ-XbC" firstAttribute="leading" secondItem="YI3-ni-eQX" secondAttribute="leading" id="4ab-jw-mb0"/>
                                     <constraint firstAttribute="trailing" secondItem="6aw-iA-A5G" secondAttribute="trailing" id="BRO-JO-oy2"/>
@@ -852,14 +854,14 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="GL9-dr-PWQ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="YI3-ni-eQX" firstAttribute="top" secondItem="GL9-dr-PWQ" secondAttribute="top" id="Z2W-2W-yeL"/>
                             <constraint firstItem="GL9-dr-PWQ" firstAttribute="trailing" secondItem="YI3-ni-eQX" secondAttribute="trailing" id="ZjF-4e-1c4"/>
                             <constraint firstItem="YI3-ni-eQX" firstAttribute="leading" secondItem="GL9-dr-PWQ" secondAttribute="leading" id="epO-JR-yDD"/>
                             <constraint firstItem="GL9-dr-PWQ" firstAttribute="bottom" secondItem="YI3-ni-eQX" secondAttribute="bottom" id="ysR-Y0-u4J"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="GL9-dr-PWQ"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="여행프로필" image="airplane" catalog="system" id="Ln5-3b-m3G"/>
                     <connections>
@@ -923,7 +925,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="EUc-EQ-1Pe">
                                                     <rect key="frame" x="0.0" y="109" width="374" height="70"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vt1-wB-b2C">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vt1-wB-b2C">
                                                             <rect key="frame" x="0.0" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <state key="normal" title="취소">
@@ -933,7 +935,7 @@
                                                                 <action selector="cancelButtonTapped:" destination="oiW-sK-s0f" eventType="touchUpInside" id="g3E-wQ-axe"/>
                                                             </connections>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ha6-Yg-38H">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ha6-Yg-38H">
                                                             <rect key="frame" x="187" y="0.0" width="187" height="70"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <state key="normal" title="완료">
@@ -954,7 +956,7 @@
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstItem="Xft-Lx-5eQ" firstAttribute="top" secondItem="h3p-Pl-e1l" secondAttribute="top" constant="20" id="EDw-D1-zt1"/>
                                                 <constraint firstAttribute="bottom" secondItem="EUc-EQ-1Pe" secondAttribute="bottom" id="Nfh-nV-TtX"/>
@@ -980,7 +982,8 @@
                                 <blurEffect style="dark"/>
                             </visualEffectView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="TZg-A5-mcJ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="ufc-1i-Y1E" firstAttribute="top" secondItem="Giw-yE-nho" secondAttribute="top" id="32L-jQ-E88"/>
                             <constraint firstItem="h3p-Pl-e1l" firstAttribute="height" secondItem="Giw-yE-nho" secondAttribute="height" multiplier="0.2" id="Hpq-L1-ir2"/>
@@ -988,7 +991,6 @@
                             <constraint firstItem="ufc-1i-Y1E" firstAttribute="leading" secondItem="Giw-yE-nho" secondAttribute="leading" id="ZbB-hu-HEa"/>
                             <constraint firstAttribute="bottom" secondItem="ufc-1i-Y1E" secondAttribute="bottom" id="xc4-ZR-xYy"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="TZg-A5-mcJ"/>
                     </view>
                     <connections>
                         <outlet property="titleTextField" destination="Xft-Lx-5eQ" id="NDF-qG-jZ7"/>
@@ -1008,7 +1010,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020년 11월 17일 4:08:51" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ImO-lf-XQ3">
-                                <rect key="frame" x="123" y="59" width="168.5" height="18"/>
+                                <rect key="frame" x="123" y="59" width="168" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -1026,7 +1028,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="US$ 7.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4wV-KP-wum">
-                                                <rect key="frame" x="154" y="61.5" width="106.5" height="30"/>
+                                                <rect key="frame" x="154.5" y="61.5" width="105.5" height="30"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
                                                 <color key="textColor" name="deleteButtonColor"/>
                                                 <nil key="highlightedColor"/>
@@ -1039,7 +1041,7 @@
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Ar-ih-n1d" userLabel="seperator">
                                                 <rect key="frame" x="20" y="132.5" width="374" height="1"/>
-                                                <color key="backgroundColor" systemColor="systemGray5Color" red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Fdc-go-kXJ"/>
                                                 </constraints>
@@ -1100,13 +1102,13 @@
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="예산명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yxl-gY-oUx">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="339" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="339.5" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USD" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EdU-9L-4nm">
-                                                                        <rect key="frame" x="339" y="0.0" width="35" height="20.5"/>
+                                                                        <rect key="frame" x="339.5" y="0.0" width="34.5" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
@@ -1117,13 +1119,13 @@
                                                                 <rect key="frame" x="0.0" y="28.5" width="374" height="20.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="환율" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LBI-bm-1g8">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="199.5" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="201" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USD 1.00 = KRW 1,096" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Khp-bb-Ych">
-                                                                        <rect key="frame" x="199.5" y="0.0" width="174.5" height="20.5"/>
+                                                                        <rect key="frame" x="201" y="0.0" width="173" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
@@ -1143,7 +1145,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="uOJ-NV-xEH" userLabel="Button Stack View">
                                                 <rect key="frame" x="124" y="776.5" width="166" height="81"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Qv-Go-eCZ">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Qv-Go-eCZ">
                                                         <rect key="frame" x="0.0" y="0.0" width="166" height="38"/>
                                                         <color key="backgroundColor" name="lightMainColor"/>
                                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="0.0" maxY="10"/>
@@ -1159,7 +1161,7 @@
                                                             <action selector="editButtonTapped:" destination="n0l-Qt-t7z" eventType="touchUpInside" id="leZ-S8-6gh"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6DE-yh-NZb">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6DE-yh-NZb">
                                                         <rect key="frame" x="0.0" y="43" width="166" height="38"/>
                                                         <color key="backgroundColor" name="deleteButtonColor"/>
                                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="0.0" maxY="10"/>
@@ -1178,7 +1180,7 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="4wV-KP-wum" firstAttribute="top" secondItem="3iv-Zv-NJB" secondAttribute="bottom" constant="10" id="5zx-Mf-QXy"/>
                                             <constraint firstItem="4wV-KP-wum" firstAttribute="centerX" secondItem="p69-4J-mh8" secondAttribute="centerX" id="6Kw-9G-1Re"/>
@@ -1211,7 +1213,7 @@
                                     <constraint firstAttribute="trailing" secondItem="p69-4J-mh8" secondAttribute="trailing" id="irl-UI-GqD"/>
                                 </constraints>
                             </scrollView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eHk-JU-XwN">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eHk-JU-XwN">
                                 <rect key="frame" x="0.0" y="821" width="414" height="41"/>
                                 <color key="backgroundColor" name="mainColor"/>
                                 <state key="normal" title="닫기">
@@ -1226,7 +1228,8 @@
                                 <color key="backgroundColor" name="mainColor"/>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="qNU-nu-0oe"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="qNU-nu-0oe" firstAttribute="bottom" secondItem="eHk-JU-XwN" secondAttribute="bottom" id="1Qx-0Q-w66"/>
                             <constraint firstItem="nEJ-zQ-SvF" firstAttribute="top" secondItem="ImO-lf-XQ3" secondAttribute="bottom" constant="20" id="APM-Je-8rx"/>
@@ -1245,7 +1248,6 @@
                             <constraint firstItem="eHk-JU-XwN" firstAttribute="leading" secondItem="qNU-nu-0oe" secondAttribute="leading" id="wzq-CE-hr4"/>
                             <constraint firstItem="qNU-nu-0oe" firstAttribute="trailing" secondItem="eHk-JU-XwN" secondAttribute="trailing" id="zc8-mA-Vls"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="qNU-nu-0oe"/>
                     </view>
                     <connections>
                         <outlet property="amountLabel" destination="4wV-KP-wum" id="ZlA-ef-kD6"/>
@@ -1271,7 +1273,7 @@
     </scenes>
     <resources>
         <image name="airplane" catalog="system" width="128" height="115"/>
-        <image name="chart.pie.fill" catalog="system" width="128" height="124"/>
+        <image name="chart.pie.fill" catalog="system" width="128" height="121"/>
         <image name="historyImage" width="512" height="512"/>
         <image name="isPrepareFalse" width="64" height="64"/>
         <image name="list.bullet" catalog="system" width="128" height="88"/>
@@ -1301,5 +1303,17 @@
         <namedColor name="mainColor">
             <color red="0.46299999952316284" green="0.69800001382827759" blue="0.89800000190734863" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
### Issue Number
Close #238

### 변경사항
- 지출 추가화면에서 계산 식 및 계산된 금액에 대해 NumberFormat 적용하여 숫자가 아주 커질 시, e 형태로 표현되는 것을 방지
- 계산 식에 `,` 가 포함될 때, 에러가 발생하는 문제를 방지하기 위해, 수식 문자열에서 `,` 제거
- nan 이나 infinite 경우, 저장되지 않도록 처리

- 지출 추가화면의 DatePicker 의 위치를 중앙으로 놓기 위해 Constraints 수정

### 새로운 기능


### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
