### PR TITLE
지출/예산 추가화면 DatePicker 깨지는 문제 해결

### DIFF
--- a/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.xib
+++ b/BoostPocket/BoostPocket/TravelDetailScene/AddHistoryScene/AddHistoryViewController.xib
@@ -313,41 +313,39 @@
                     <rect key="frame" x="0.0" y="503.5" width="414" height="45"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RWq-Ek-2dx">
-                            <rect key="frame" x="0.0" y="0.0" width="259" height="45"/>
+                            <rect key="frame" x="0.0" y="0.0" width="283.5" height="45"/>
                             <subviews>
                                 <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="FBN-Xp-w8g">
-                                    <rect key="frame" x="20" y="0.0" width="219" height="45"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="219" id="UH0-dh-oF4"/>
-                                    </constraints>
+                                    <rect key="frame" x="10" y="0.0" width="263.5" height="45"/>
                                     <locale key="locale" localeIdentifier="ko"/>
                                 </datePicker>
                             </subviews>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstItem="FBN-Xp-w8g" firstAttribute="centerX" secondItem="RWq-Ek-2dx" secondAttribute="centerX" id="40g-uB-nBS"/>
                                 <constraint firstAttribute="bottom" secondItem="FBN-Xp-w8g" secondAttribute="bottom" id="Rhp-K0-hy3"/>
                                 <constraint firstItem="FBN-Xp-w8g" firstAttribute="top" secondItem="RWq-Ek-2dx" secondAttribute="top" id="SUa-oX-KvR"/>
+                                <constraint firstItem="FBN-Xp-w8g" firstAttribute="centerX" secondItem="RWq-Ek-2dx" secondAttribute="centerX" id="arC-Bt-6wQ"/>
+                                <constraint firstAttribute="trailing" secondItem="FBN-Xp-w8g" secondAttribute="trailing" constant="10" id="juD-zf-Lrh"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5UH-g4-mMe" userLabel="Picture">
-                            <rect key="frame" x="259" y="0.0" width="51.5" height="45"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5UH-g4-mMe" userLabel="Picture">
+                            <rect key="frame" x="283.5" y="0.0" width="29" height="45"/>
                             <color key="tintColor" systemColor="systemGray3Color"/>
                             <state key="normal" image="photo" catalog="system"/>
                             <connections>
                                 <action selector="addImageButtonTapped:" destination="-1" eventType="touchUpInside" id="LG4-Eq-Ho1"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14w-LZ-14y" userLabel="Memo">
-                            <rect key="frame" x="310.5" y="0.0" width="52" height="45"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14w-LZ-14y" userLabel="Memo">
+                            <rect key="frame" x="312.5" y="0.0" width="29" height="45"/>
                             <color key="tintColor" systemColor="systemGray3Color"/>
                             <state key="normal" image="list.dash" catalog="system"/>
                             <connections>
                                 <action selector="addMemoButtonTapped:" destination="-1" eventType="touchUpInside" id="c6o-T4-531"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-oJ-N8p">
-                            <rect key="frame" x="362.5" y="0.0" width="51.5" height="45"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-oJ-N8p">
+                            <rect key="frame" x="341.5" y="0.0" width="72.5" height="45"/>
                             <state key="normal" title="저장"/>
                             <connections>
                                 <action selector="saveButtonTapped:" destination="-1" eventType="touchUpInside" id="XTN-WY-cDN"/>
@@ -355,7 +353,8 @@
                         </button>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="14w-LZ-14y" firstAttribute="width" secondItem="5UH-g4-mMe" secondAttribute="width" id="OGg-Z8-d2O"/>
+                        <constraint firstItem="14w-LZ-14y" firstAttribute="width" secondItem="QIf-oJ-N8p" secondAttribute="width" multiplier="0.4" id="EAl-cu-bzM"/>
+                        <constraint firstItem="5UH-g4-mMe" firstAttribute="width" secondItem="14w-LZ-14y" secondAttribute="width" id="qnK-cw-y7b"/>
                     </constraints>
                 </stackView>
                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RY6-19-kNJ">
@@ -388,13 +387,13 @@
                 <constraint firstItem="lci-Ei-eGZ" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="4iX-Zc-Elj"/>
                 <constraint firstItem="0kX-Kl-MDd" firstAttribute="top" secondItem="Uvo-Ni-ty9" secondAttribute="bottom" id="5dm-zO-9oG"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="heQ-Ap-lf8" secondAttribute="trailing" id="8sN-sz-tei"/>
-                <constraint firstItem="5UH-g4-mMe" firstAttribute="leading" secondItem="o0M-UP-Rk5" secondAttribute="centerX" id="A3y-gd-0J7"/>
                 <constraint firstItem="lci-Ei-eGZ" firstAttribute="width" secondItem="i5M-Pr-FkT" secondAttribute="width" multiplier="0.7" id="EGw-ox-G4Y"/>
                 <constraint firstItem="heQ-Ap-lf8" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="G9O-nJ-83v"/>
                 <constraint firstItem="lci-Ei-eGZ" firstAttribute="top" secondItem="heQ-Ap-lf8" secondAttribute="bottom" constant="10" id="JEx-NU-Fnu"/>
                 <constraint firstItem="fLx-PJ-SRJ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="JPT-bd-AAd"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fLx-PJ-SRJ" secondAttribute="trailing" id="JaW-8O-dJs"/>
                 <constraint firstItem="Uvo-Ni-ty9" firstAttribute="top" secondItem="RY6-19-kNJ" secondAttribute="bottom" constant="15" id="LX4-ke-6CR"/>
+                <constraint firstItem="QIf-oJ-N8p" firstAttribute="width" secondItem="Yad-QF-DSb" secondAttribute="width" multiplier="0.7" id="MVa-4c-HBQ"/>
                 <constraint firstItem="0kX-Kl-MDd" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.35" id="NK5-JK-lX7"/>
                 <constraint firstItem="heQ-Ap-lf8" firstAttribute="top" secondItem="fLx-PJ-SRJ" secondAttribute="bottom" constant="10" id="NWT-Gj-UAR"/>
                 <constraint firstItem="Uvo-Ni-ty9" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Q7Q-qd-fTQ"/>
@@ -403,11 +402,9 @@
                 <constraint firstItem="Uvo-Ni-ty9" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.05" id="aew-P5-zSc"/>
                 <constraint firstItem="fLx-PJ-SRJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="dht-aF-fyi"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Uvo-Ni-ty9" secondAttribute="trailing" id="fGA-53-mMW"/>
-                <constraint firstItem="5UH-g4-mMe" firstAttribute="width" secondItem="o0M-UP-Rk5" secondAttribute="width" multiplier="0.5" id="h9l-Ce-c51"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="0kX-Kl-MDd" secondAttribute="bottom" id="hvk-1c-ZWd"/>
                 <constraint firstItem="0kX-Kl-MDd" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="m7l-qn-khK"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="0kX-Kl-MDd" secondAttribute="trailing" id="yGV-oI-Eax"/>
-                <constraint firstItem="QIf-oJ-N8p" firstAttribute="leading" secondItem="Yad-QF-DSb" secondAttribute="centerX" id="yzg-D4-CxD"/>
                 <constraint firstItem="RY6-19-kNJ" firstAttribute="top" secondItem="lci-Ei-eGZ" secondAttribute="bottom" constant="10" id="zB8-II-ahG"/>
             </constraints>
             <point key="canvasLocation" x="131.8840579710145" y="150.66964285714286"/>


### PR DESCRIPTION
### Issue Number
Close #244

### 변경사항
- 지출/예산 추가화면에서 DatePicker의 날짜 길이에 따라서 날짜 텍스트가 잘리는 문제 해결

### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
