### PR TITLE
PersistenceManager 테스트코드 보강

### DIFF
--- a/BoostPocket/BoostPocket/Models/PersistenceManager.swift
+++ b/BoostPocket/BoostPocket/Models/PersistenceManager.swift
@@ -26,6 +26,7 @@ protocol PersistenceManagable: AnyObject {
     func delete<T>(deletingObject: T) -> Bool
     func count<T: NSManagedObject>(request: NSFetchRequest<T>) -> Int?
     func setupTravelInfo(travelInfo: TravelInfo, completion: @escaping (Travel?) -> Void)
+    func setupCountries(with data: ExchangeRate)
     @discardableResult func saveContext() -> Bool
 }
 
@@ -79,8 +80,7 @@ class PersistenceManager: PersistenceManagable {
         }
     }
     
-    // TODO: - 테스트코드 작성하기
-    private func setupCountries(with data: ExchangeRate) {
+    func setupCountries(with data: ExchangeRate) {
         let koreaLocale = NSLocale(localeIdentifier: "ko_KR")
         let identifiers = NSLocale.availableLocaleIdentifiers
         let countryDictionary = filterCountries(identifiers, rates: data.rates)

--- a/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
+++ b/BoostPocket/BoostPocketTests/PersistenceManagerTests/PersistenceManagerTests.swift
@@ -50,6 +50,35 @@ class PersistenceManagerTests: XCTestCase {
         historyInfo = nil
     }
     
+    func test_persistenceManager_createCountriesWithAPIRequest_with_no_countries() {
+        let exchangeRateExpectation = XCTestExpectation(description: "Successfully Requested Exchange Rate")
+        
+        var createCountriesResult: Bool = false
+        persistenceManagerStub.createCountriesWithAPIRequest { result in
+            createCountriesResult = result
+            exchangeRateExpectation.fulfill()
+        }
+        
+        wait(for: [exchangeRateExpectation], timeout: 2)
+        XCTAssertTrue(createCountriesResult)
+    }
+    
+    func test_persistenceManager_createCountriesWithAPIRequest_with_countries() {
+        var createdCountry: Country?
+        persistenceManagerStub.createObject(newObjectInfo: countryInfo) { country in
+            createdCountry = country as? Country
+        }
+        
+        XCTAssertNotNil(createdCountry)
+        
+        var createCountriesResult: Bool = false
+        persistenceManagerStub.createCountriesWithAPIRequest { result in
+            createCountriesResult = result
+        }
+        
+        XCTAssertTrue(createCountriesResult)
+    }
+    
     func test_persistenceManager_filterCountries() {
         let identifiers = ["ko_KR", "ja_JP"]
         let rates = ["KRW": 1.0, "JPY": 0.0941570188]


### PR DESCRIPTION
### Issue Number
Close #257 

### 변경사항
- createCountriesWithAPIRequest 함수에 대한 테스트코드 작성
- 저장된 Country정보가 있을 때와 없을 때로 구분하여 테스트코드를 작성
- 환율정보를 정상적으로 가져왔다고 가정하고 setupCountries 함수 호출에 대한 테스트 코드 작성

### 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
