### PR TITLE
국가 선택 화면 테이블뷰 selection 버그 수정

### DIFF
--- a/BoostPocket/BoostPocket/CountryListScene/View/CountryListViewController.swift
+++ b/BoostPocket/BoostPocket/CountryListScene/View/CountryListViewController.swift
@@ -44,6 +44,7 @@ class CountryListViewController: UIViewController {
     
     private func configureNavigationBar() {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .plain, target: self, action: #selector(doneButtonTapped))
+        navigationItem.rightBarButtonItem?.isEnabled = false
         title = "여행할 나라를 선택해주세요"
     }
     
@@ -61,14 +62,10 @@ class CountryListViewController: UIViewController {
     }
     
     @objc func doneButtonTapped() {
-        guard let selectedIndexPath = countryListTableView.indexPathForSelectedRow else {
-            dismiss(animated: true, completion: nil)
-            return
-        }
+        guard let selectedIndexPath = countryListTableView.indexPathForSelectedRow else { return }
         
         dismiss(animated: true) { [weak self] in
             guard let selectedCountryItemViewModel = self?.dataSource.itemIdentifier(for: selectedIndexPath) else {
-                // TODO: - 에러처리
                 return
             }
             self?.doneButtonHandler?(selectedCountryItemViewModel)
@@ -114,6 +111,7 @@ class CountryListViewController: UIViewController {
 extension CountryListViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        navigationItem.rightBarButtonItem?.isEnabled = true
         let cell = tableView.cellForRow(at: indexPath)
         cell?.accessoryType = .checkmark
     }
@@ -122,7 +120,6 @@ extension CountryListViewController: UITableViewDelegate {
         let cell = tableView.cellForRow(at: indexPath)
         cell?.accessoryType = .none
     }
-    
 }
 
 extension CountryListViewController: UISearchBarDelegate {

--- a/BoostPocket/BoostPocket/CountryListScene/View/CountryListViewController.swift
+++ b/BoostPocket/BoostPocket/CountryListScene/View/CountryListViewController.swift
@@ -110,11 +110,21 @@ class CountryListViewController: UIViewController {
 
 extension CountryListViewController: UITableViewDelegate {
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        if let selectedIndexPath = tableView.indexPathForSelectedRow, selectedIndexPath == indexPath {
+          navigationItem.rightBarButtonItem?.isEnabled = false
+          tableView.deselectRow(at: indexPath, animated: true)
+          let cell = tableView.cellForRow(at: indexPath)
+          cell?.accessoryType = .none
+          return nil
+        }
+        
         navigationItem.rightBarButtonItem?.isEnabled = true
         let cell = tableView.cellForRow(at: indexPath)
         cell?.accessoryType = .checkmark
-    }
+        
+        return indexPath
+      }
     
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         let cell = tableView.cellForRow(at: indexPath)


### PR DESCRIPTION
### Issue Number
Close #279 

### 변경사항
- 여행 추가 시 국가 선택이 안되어 있으면 확인 버튼 비활성화
- 국가 선택 테이블뷰 셀 두번 탭하면 deselect



### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
